### PR TITLE
mjpg-streamer: disable experimental HTTP management and its rate limiter

### DIFF
--- a/meta-opencentauri/recipes-apps/mjpg-streamer/mjpg-streamer_1.0.0.bb
+++ b/meta-opencentauri/recipes-apps/mjpg-streamer/mjpg-streamer_1.0.0.bb
@@ -14,7 +14,6 @@ S = "${WORKDIR}/git/mjpg-streamer-experimental"
 inherit cmake update-rc.d
 
 OECMAKE_GENERATOR="Unix Makefiles"
-EXTRA_OECMAKE = "-DENABLE_HTTP_MANAGEMENT=ON"
 TARGET_CFLAGS += "-fcommon"
 
 INITSCRIPT_NAME = "mjpg-streamer"


### PR DESCRIPTION
The HTTP management activated some rate limiter that did not work well with mainsail.