### PR TITLE
kernel: fix LCD panel timings, polarity, and add RB swap support

### DIFF
--- a/meta-opencentauri/recipes-kernel/linux/linux-mainline/elegoo-centauri-carbon1/0002-drm-add-RB-channel-swap-support-for-panels-with-swap.patch
+++ b/meta-opencentauri/recipes-kernel/linux/linux-mainline/elegoo-centauri-carbon1/0002-drm-add-RB-channel-swap-support-for-panels-with-swap.patch
@@ -1,0 +1,80 @@
+From e5add7b457551a548baab863aebcc58ce476dce9 Mon Sep 17 00:00:00 2001
+From: Timo V <timiv@users.noreply.github.com>
+Date: Tue, 10 Mar 2026 19:29:57 +0100
+Subject: [PATCH] drm: add RB channel swap support for panels with swapped R/B
+ lines
+
+Two changes are needed to support panels whose physical Red and Blue
+data lines are swapped relative to the SoC TCON output:
+
+1. panel-simple: parse the 'bus-format' DT property in panel_dpi_probe()
+   so that DT-only panels can declare their media bus format (e.g.
+   MEDIA_BUS_FMT_BGR888_1X24 = 0x1013) and have it propagated through
+   drm_display_info.
+
+2. sun4i-tcon: check the connector's bus_format in
+   sun4i_tcon0_mode_set_rgb(). When the panel reports BGR888, set the
+   TCON0 hardware RB swap bit (bit 23 of TCON0_CTL register) to swap
+   the R and B channels without software colour conversion.
+
+This matches the Allwinner vendor BSP 'lcd_rb_swap' functionality.
+
+Upstream-Status: Pending [Not submitted to upstream yet]
+Signed-off-by: Timo V <timiv@users.noreply.github.com>
+---
+ drivers/gpu/drm/panel/panel-simple.c |  3 +++
+ drivers/gpu/drm/sun4i/sun4i_tcon.c   | 14 ++++++++++++++
+ drivers/gpu/drm/sun4i/sun4i_tcon.h   |  1 +
+ 3 files changed, 18 insertions(+)
+
+diff --git a/drivers/gpu/drm/panel/panel-simple.c b/drivers/gpu/drm/panel/panel-simple.c
+index 37fe54c34..897e369b5 100644
+--- a/drivers/gpu/drm/panel/panel-simple.c
++++ b/drivers/gpu/drm/panel/panel-simple.c
+@@ -488,6 +488,9 @@ static int panel_dpi_probe(struct device *dev,
+ 	of_property_read_u32(np, "width-mm", &desc->size.width);
+ 	of_property_read_u32(np, "height-mm", &desc->size.height);
+ 
++	/* Allow DT to declare the media bus format (e.g. BGR888 for RB swap) */
++	of_property_read_u32(np, "bus-format", &desc->bus_format);
++
+ 	/* Extract bus_flags from display_timing */
+ 	bus_flags = 0;
+ 	vm.flags = timing->flags;
+diff --git a/drivers/gpu/drm/sun4i/sun4i_tcon.c b/drivers/gpu/drm/sun4i/sun4i_tcon.c
+index a1a2c845a..f450ef1df 100644
+--- a/drivers/gpu/drm/sun4i/sun4i_tcon.c
++++ b/drivers/gpu/drm/sun4i/sun4i_tcon.c
+@@ -586,6 +586,20 @@ static void sun4i_tcon0_mode_set_rgb(struct sun4i_tcon *tcon,
+ 			   SUN4I_TCON0_IO_POL_DE_NEGATIVE,
+ 			   val);
+ 
++	/*
++	 * If the panel reports BGR bus format, enable the TCON0 hardware
++	 * RB swap (bit 23 of TCON0_CTL) to compensate for the swapped
++	 * Red and Blue data lines on the panel's physical connector.
++	 */
++	if (info->num_bus_formats == 1 &&
++	    info->bus_formats[0] == MEDIA_BUS_FMT_BGR888_1X24)
++		regmap_update_bits(tcon->regs, SUN4I_TCON0_CTL_REG,
++				   SUN4I_TCON0_CTL_RB_SWAP,
++				   SUN4I_TCON0_CTL_RB_SWAP);
++	else
++		regmap_update_bits(tcon->regs, SUN4I_TCON0_CTL_REG,
++				   SUN4I_TCON0_CTL_RB_SWAP, 0);
++
+ 	/* Map output pins to channel 0 */
+ 	regmap_update_bits(tcon->regs, SUN4I_TCON_GCTL_REG,
+ 			   SUN4I_TCON_GCTL_IOMAP_MASK,
+diff --git a/drivers/gpu/drm/sun4i/sun4i_tcon.h b/drivers/gpu/drm/sun4i/sun4i_tcon.h
+index fa23aa23f..0db5b5ef2 100644
+--- a/drivers/gpu/drm/sun4i/sun4i_tcon.h
++++ b/drivers/gpu/drm/sun4i/sun4i_tcon.h
+@@ -54,6 +54,7 @@
+ #define SUN4I_TCON0_CTL_TCON_ENABLE			BIT(31)
+ #define SUN4I_TCON0_CTL_IF_MASK				GENMASK(25, 24)
+ #define SUN4I_TCON0_CTL_IF_8080				(1 << 24)
++#define SUN4I_TCON0_CTL_RB_SWAP				BIT(23)
+ #define SUN4I_TCON0_CTL_CLK_DELAY_MASK			GENMASK(8, 4)
+ #define SUN4I_TCON0_CTL_CLK_DELAY(delay)		((delay << 4) & SUN4I_TCON0_CTL_CLK_DELAY_MASK)
+ #define SUN4I_TCON0_CTL_SRC_SEL_MASK			GENMASK(2, 0)

--- a/meta-opencentauri/recipes-kernel/linux/linux-mainline/elegoo-centauri-carbon1/elegoo-centauri-carbon1.dts
+++ b/meta-opencentauri/recipes-kernel/linux/linux-mainline/elegoo-centauri-carbon1/elegoo-centauri-carbon1.dts
@@ -58,6 +58,7 @@
 
 	panel {
 		compatible = "panel-dpi";
+		bus-format = <0x1013>;
 		power-supply = <&reg_3v3>;
 		// backlight = <&backlight>;
 		// enable-gpios = <&pio 1 8 GPIO_ACTIVE_HIGH>; /* PB8 */
@@ -73,16 +74,16 @@
 			clock-frequency = <9000000>;
 			hactive = <480>;
 			vactive = <272>;
-			hback-porch = <43>;
-			hfront-porch = <4>;
+			hback-porch = <39>;
+			hfront-porch = <8>;
 			hsync-len = <4>;
-			vback-porch = <12>;
-			vfront-porch = <4>;
+			vback-porch = <8>;
+			vfront-porch = <8>;
 			vsync-len = <4>;
 			de-active = <1>;
 			hsync-active = <0>;
 			vsync-active = <0>;
-			pixelclk-active = <0>;
+			pixelclk-active = <1>;
 		};
 	};
 

--- a/meta-opencentauri/recipes-kernel/linux/linux-mainline_%.bbappend
+++ b/meta-opencentauri/recipes-kernel/linux/linux-mainline_%.bbappend
@@ -10,6 +10,7 @@ SRC_URI:append:elegoo-centauri-carbon1 = " \
 	file://sunxi_r528_remoteproc.c;subdir=linux-6.6.85/drivers/remoteproc \
 	file://0001-Add-elegoo-centauri-carbon1.dts.patch \
 	file://0001-Add-support-for-r528-msgbox-and-remoteproc.patch \
+	file://0002-drm-add-RB-channel-swap-support-for-panels-with-swap.patch \
 	file://fragment.cfg \
 	file://squashfs-overlayfs.cfg \
 	file://kernel-size-reduction.cfg \


### PR DESCRIPTION
Update the kernel device tree for the Elegoo Centauri Carbon 1:
- Fix back/front porch values to match vendor BSP (hbp 43->39, hfp 4->8, vbp 12->8, vfp 4->8, keeping total ht=531/vt=292)
- Set pixelclk-active=1 (rising edge, vendor phase 0)
- Add bus-format=0x1013 (MEDIA_BUS_FMT_BGR888_1X24) for RB swap

Add a single kernel patch (generated via devtool) that:
- Teaches panel-simple to parse the 'bus-format' DT property
- Adds TCON0 RB swap (bit 23) support to sun4i-tcon driver