### PR TITLE
lcd: disable screen in addition to backlight to prevent ghosting

### DIFF
--- a/meta-opencentauri/recipes-kernel/linux/linux-mainline/elegoo-centauri-carbon1/elegoo-centauri-carbon1.dts
+++ b/meta-opencentauri/recipes-kernel/linux/linux-mainline/elegoo-centauri-carbon1/elegoo-centauri-carbon1.dts
@@ -48,21 +48,18 @@
 		vin-supply = <&reg_vcc5v>;
 	};
 
-	// backlight: backlight {
-	// 	compatible = "pwm-backlight";
-	// 	pwms = <&pwm 7 20000 0>;
-	// 	brightness-levels = <0 4 8 16 32 64 128 255>;
-	// 	default-brightness-level = <7>;
-	// 	enable-gpios = <&pio 1 8 GPIO_ACTIVE_HIGH>; /* PB8 */
-	// };
+	backlight: backlight {
+		compatible = "gpio-backlight";
+		gpios = <&pio 3 22 GPIO_ACTIVE_HIGH>; /* PD22 */
+		default-on;
+	};
 
 	panel {
 		compatible = "panel-dpi";
 		bus-format = <0x1013>;
 		power-supply = <&reg_3v3>;
-		// backlight = <&backlight>;
-		// enable-gpios = <&pio 1 8 GPIO_ACTIVE_HIGH>; /* PB8 */
-		enable-gpios = <&pio 3 22 GPIO_ACTIVE_HIGH>; /* PB8 */
+		backlight = <&backlight>;
+		enable-gpios = <&pio 1 8 GPIO_ACTIVE_HIGH>; /* PB8 */
 
 		port {
 			panel_in: endpoint {


### PR DESCRIPTION
The LCD panel suffered from image retention (ghosting) after the screen went dark during guppyscreen's sleep mode.

Two problems combined to cause this:

1. The DTS had enable-gpios on the panel node pointing to PD22 (the backlight pin), while PB8 (panel enable) was never touched. As a result, the LCD module stayed permanently powered.
2. guppyscreen called FB_BLANK_NORMAL, which only turns off the backlight. The DRM DPMS Off path, which also pulls the panel power pin LOW and disables the TCON, was never triggered.
With the backlight off but the panel still powered and receiving no refresh signals, the LC cells retained charge from the last displayed image.