### PR TITLE
Wait 3s after toolhead bootloader flash

### DIFF
--- a/meta-opencentauri/recipes-apps/klipper/files/klipper-firmware-toolhead-init-d
+++ b/meta-opencentauri/recipes-apps/klipper/files/klipper-firmware-toolhead-init-d
@@ -28,6 +28,7 @@ case "$1" in
         if mcu-flasher --firmware $KATAPULT_DEPLOYER --no-wait $SERIALPORT --firmware-version 6.4.9; then
             echo "Bootloader deployer flashed successfully, clearing installed version."
             rm -f $INSTALLED_VERSION
+            sleep 3 # Wait for the device to reset after bootloader flash
         else
             echo "Bootloader already up to date."
         fi


### PR DESCRIPTION
Maybe we should just check if /dev/ttyACM0 exists for faster exec time, but this will probably work too.

Untested.