### PR TITLE
config: Improve homing

### DIFF
--- a/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
+++ b/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
@@ -4,7 +4,7 @@
 # -----
 
 [gcode_macro _GLOBAL_VARS]
-variable_extruder_target: 230 
+variable_extruder_target: 230
 gcode:
 
 [gcode_macro PRINT_START]
@@ -269,20 +269,11 @@ gcode:
     M400
     G28 X # Home X
 
-    # Move away
-    G91
-    G1 X-20 F4800
-    G90
 
 [gcode_macro _HOME_Y]
 gcode:
     M400
     G28 Y # Home Y
-
-    # Move away
-    G91
-    G1 Y30 F4800
-    G90
 
 [homing_override]
 axes: yxz
@@ -299,6 +290,10 @@ gcode:
 
     G4 P500
 
+    {% if home_all or 'Y' in params %}
+      _HOME_Y
+    {% endif %}
+
     {% if home_all or 'X' in params %}
       _HOME_X
     {% endif %}
@@ -306,22 +301,20 @@ gcode:
     {% if home_all or 'Y' in params %}
       _HOME_Y
     {% endif %}
-    
-    {% if home_all or ('X' in params and 'Y' in params) %}
+
+    {% if home_all or 'X' in params %}
       _HOME_X
     {% endif %}
 
-    {% if home_all or ('X' in params and 'Y' in params) %}
-      _HOME_Y
-    {% endif %}
 
     # Restore running current after homing
     SET_TMC_CURRENT STEPPER=stepper_x CURRENT={RUN_CURRENT_X}
     SET_TMC_CURRENT STEPPER=stepper_y CURRENT={RUN_CURRENT_Y}
-    
+
     {% if home_all or 'Z' in params %}
         G90 # Absolute positioning
         G1 X125 Y125 F15000 # Move to center of the bed for Z homing
+        M400 # Wait for moves to finish
         G28 Z # Home Z
         G0 Z10 F1500 # Move down after homing
     {% endif %}

--- a/meta-opencentauri/recipes-apps/klipper/files/mainboard.cfg
+++ b/meta-opencentauri/recipes-apps/klipper/files/mainboard.cfg
@@ -18,7 +18,7 @@ position_endstop: 256.499
 position_max: 256.5
 position_min: -2.01
 homing_speed: 80
-homing_retract_dist: 3
+homing_retract_dist: 20
 rotation_distance: 39.872
 
 [stepper_y]
@@ -32,7 +32,7 @@ position_endstop: -2.5
 position_max: 270.000000
 position_min: -2.51
 homing_speed: 80
-homing_retract_dist: 3
+homing_retract_dist: 30
 rotation_distance: 39.872
 
 [stepper_z]


### PR DESCRIPTION
The current homing macros had a few flaws:

1. If a bed mesh was loaded klipper aborted homing of Z if the G1 move was not yet complete. This is fixed by adding an additional M400.

2. It was not possible to home X / Y individually as the second home move was always done.

3. Homing to the front right side requires Y to be homed before X as otherwise the toolhead might crash into the lever of the poop tray, if it starts there.