### PR TITLE
config: Use a stable serial port path for toolhead

### DIFF
--- a/meta-opencentauri/recipes-apps/klipper/files/klipper-firmware-toolhead-init-d
+++ b/meta-opencentauri/recipes-apps/klipper/files/klipper-firmware-toolhead-init-d
@@ -12,7 +12,7 @@ FIRMWARE="/lib/firmware/klipper-toolhead.bin"
 FIRMWARE_VERSION="/lib/firmware/klipper-toolhead.bin.ver"
 KATAPULT_DEPLOYER="/lib/firmware/katapult-deployer-toolhead.bin"
 INSTALLED_VERSION="/etc/toolhead.ver"
-SERIALPORT="/dev/ttyACM0"
+SERIALPORT="/dev/serial/by-path/platform-4101400.usb-usb-0:1:1.0"
 GPIO="140"
 
 update(){

--- a/meta-opencentauri/recipes-apps/klipper/files/toolhead.cfg
+++ b/meta-opencentauri/recipes-apps/klipper/files/toolhead.cfg
@@ -4,7 +4,7 @@
 # -----
 
 [mcu hotend]
-serial: /dev/ttyACM0
+serial: /dev/serial/by-path/platform-4101400.usb-usb-0:1:1.0
 restart_method: command
 
 [thermistor hotend_termistor]


### PR DESCRIPTION
If other serial devices are connected, ttyACM0 might be not assigned to the toolhead. With this change, the path is changed to the actual USB port the toolhead is connected to.