### PR TITLE
grumpyscreen: Coalesce print panel file list refreshes

### DIFF
--- a/meta-opencentauri/recipes-apps/grumyscreen/files/0002-Coalesce-file-list-refreshes.patch
+++ b/meta-opencentauri/recipes-apps/grumyscreen/files/0002-Coalesce-file-list-refreshes.patch
@@ -1,0 +1,126 @@
+diff --git a/src/print_panel.cpp b/src/print_panel.cpp
+index 1c3502a..524a463 100644
+--- a/src/print_panel.cpp
++++ b/src/print_panel.cpp
+@@ -30,6 +30,9 @@ PrintPanel::PrintPanel(KWebSocketClient &websocket, std::mutex &lock, PrintStatu
+   , file_panel(file_view)
+   , print_status(ps)
+   , sorted_by(SORTED_BY_MODIFIED)
++  , refreshing_files(false)
++  , refresh_pending(false)
++  , visible(false)
+ {
+   LOG_TRACE("building print panel");
+   lv_obj_move_background(files_cont);
+@@ -91,7 +94,16 @@ void PrintPanel::populate_files(json &j) {
+ }
+
+ void PrintPanel::handle_file_list_change(json &j) {
++  if (j["/params/0/item/root"_json_pointer] != "gcodes") {
++    return;
++  }
++
+   LOG_TRACE("file list change response {}", j.dump());
++  refresh_pending = true;
++  if (!visible) {
++    return;
++  }
++
+   subscribe();
+ }
+
+@@ -112,12 +124,19 @@ void PrintPanel::consume(json &j) {
+ }
+
+ void PrintPanel::subscribe() {
++  refresh_pending = true;
++  if (!visible || refreshing_files) {
++    return;
++  }
++
++  refreshing_files = true;
++  refresh_pending = false;
+   lv_obj_clear_flag(file_table, LV_OBJ_FLAG_CLICKABLE);
+   lv_obj_clear_flag(spinner, LV_OBJ_FLAG_HIDDEN);
+
+   ws.send_jsonrpc("server.files.list", R"({"root":"gcodes"})"_json, [this](json &d) {
+-    std::lock_guard<std::mutex> lock(lv_lock);
+-    std::string cur_path = cur_dir->full_path;
++    std::unique_lock<std::mutex> lock(lv_lock);
++    std::string cur_path = cur_dir == NULL ? "" : cur_dir->full_path;
+     root.clear();
+     cur_file = NULL;
+     cur_dir = NULL;
+@@ -129,6 +148,10 @@ void PrintPanel::subscribe() {
+     }
+
+     Tree *dir = root.find_path(KUtils::split(cur_path, '/'));
++    if (dir == NULL) {
++      dir = &root;
++    }
++
+     // need to simplify this using the directory endpoint
+     cur_dir = dir;
+
+@@ -137,6 +160,13 @@ void PrintPanel::subscribe() {
+     // Re-enable the table interaction ONLY after the data is stable
+     lv_obj_add_flag(file_table, LV_OBJ_FLAG_CLICKABLE);
+     lv_obj_add_flag(spinner, LV_OBJ_FLAG_HIDDEN);
++    refreshing_files = false;
++    if (!visible || !refresh_pending) {
++      return;
++    }
++
++    lock.unlock();
++    subscribe();
+   });
+ }
+
+@@ -154,6 +184,7 @@ void PrintPanel::foreground() {
+     print_btn.disable();
+   }
+
++  visible = true;
+   lv_obj_move_foreground(files_cont);
+   subscribe();
+ }
+@@ -298,6 +329,7 @@ void PrintPanel::handle_metadata(const std::string& full_path, json &j) {
+ void PrintPanel::handle_back_btn(lv_event_t *event) {
+   lv_obj_t *btn = lv_event_get_current_target(event);
+   if (btn == back_btn.get_container()) {
++    visible = false;
+     lv_obj_move_background(files_cont);
+     print_status.background();
+   }
+@@ -315,6 +347,8 @@ void PrintPanel::handle_print_callback(lv_event_t *event) {
+       LOG_DEBUG("printer ready to print. print file {}", cur_file->full_path);
+
+       json fname_input = {{"filename", cur_file->full_path }};
++      visible = false;
++      lv_obj_move_background(files_cont);
+       ws.send_jsonrpc("printer.print.start", fname_input);
+       print_status.foreground();
+     }
+@@ -325,6 +359,8 @@ void PrintPanel::handle_status_btn(lv_event_t *event) {
+   lv_event_code_t code = lv_event_get_code(event);
+   if (code == LV_EVENT_CLICKED && cur_file != NULL) {
+     LOG_TRACE("status button clicked");
++    visible = false;
++    lv_obj_move_background(files_cont);
+     print_status.foreground();
+   }
+ }
+diff --git a/src/print_panel.h b/src/print_panel.h
+index 3d056d1..ddffc8d 100644
+--- a/src/print_panel.h
++++ b/src/print_panel.h
+@@ -64,6 +64,9 @@ class PrintPanel : public NotifyConsumer {
+   FilePanel file_panel;
+   PrintStatusPanel &print_status;
+   uint32_t sorted_by;
++  bool refreshing_files;
++  bool refresh_pending;
++  bool visible;
+ };
+
+ #endif // __PRINT_PANEL_H__

--- a/meta-opencentauri/recipes-apps/grumyscreen/grumpyscreen_20260213.bb
+++ b/meta-opencentauri/recipes-apps/grumyscreen/grumpyscreen_20260213.bb
@@ -11,6 +11,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=1ebbd3e34237af26da5dc08a4e440464"
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 SRC_URI = "gitsm://github.com/jamesturton/grumpyscreen.git;protocol=https;branch=opencentauri \
+    file://0002-Coalesce-file-list-refreshes.patch \
     file://grumpyscreen.init \
     file://grumpyscreen.cfg \
 "


### PR DESCRIPTION
GrumpyScreen refreshes the full gcodes tree on every notify_filelist_changed event.

When Moonraker is slow or the file tree is large, those notifications can pile up and queue multiple overlapping server.files.list requests. That amplifies file-manager activity into sustained Moonraker CPU load.

Fix this by:
- tracking whether a refresh is already running
- coalescing bursts into one follow-up refresh
- ignoring notifications outside gcodes
- deferring refreshes while the panel is hidden
- falling back to the root directory if the previous directory disappears