### PR TITLE
python3: enable compiler optimizations

### DIFF
--- a/meta-opencentauri/recipes-devtools/python/python3_%.bbappend
+++ b/meta-opencentauri/recipes-devtools/python/python3_%.bbappend
@@ -1,0 +1,1 @@
+PACKAGECONFIG:append:class-target = " lto pgo"


### PR DESCRIPTION
Enable CPython link-time and profile-guided optimization for the target build.

This reduces interpreter-heavy workload time by roughly one fifth overall in Klipper-relevant hot paths such as arc generation.