### PR TITLE
klipper: add default filament runout sensor config

### DIFF
--- a/meta-opencentauri/recipes-apps/klipper/files/mainboard.cfg
+++ b/meta-opencentauri/recipes-apps/klipper/files/mainboard.cfg
@@ -122,42 +122,6 @@ idle_speed: 0
 [filament_switch_sensor filament_sensor]
 # Centauri Carbon stock runout sensor is wired to the mainboard, so keep the
 # hardware definition in klipper-readonly alongside the other board config.
+# leave pause policy to the normal Klipper sensor settings.
 switch_pin: PC0
 pause_on_runout: False
-
-[gcode_macro _FILAMENT_SENSOR_EVENT]
-description: Hook for filament sensor transitionr
-gcode:
-    {% set state = params.STATE|default("")|lower %}
-    {% if state == "inserted" %}
-        # Log to the console instead of the LCD so the message does not linger.
-        {action_respond_info("Filament inserted")}
-    {% elif state == "removed" %}
-        # Keep this as a notification hook only. Any pause/runout policy should be opt-in.
-        {action_respond_info("Filament removed")}
-    {% endif %}
-
-[gcode_macro _FILAMENT_SENSOR_WATCH]
-# Poll the hardware sensor and turn state changes into a single hook call.
-variable_initialized: 0
-variable_last_state: 0
-gcode:
-
-[delayed_gcode filament_sensor_watch]
-initial_duration: 2.0
-gcode:
-    {% set sensor = printer['filament_switch_sensor filament_sensor'] %}
-    {% set current = 1 if sensor.filament_detected else 0 %}
-    {% set vars = printer['gcode_macro _FILAMENT_SENSOR_WATCH'] %}
-    {% if vars.initialized|int == 0 %}
-        SET_GCODE_VARIABLE MACRO=_FILAMENT_SENSOR_WATCH VARIABLE=initialized VALUE=1
-        SET_GCODE_VARIABLE MACRO=_FILAMENT_SENSOR_WATCH VARIABLE=last_state VALUE={current}
-    {% elif vars.last_state|int != current %}
-        SET_GCODE_VARIABLE MACRO=_FILAMENT_SENSOR_WATCH VARIABLE=last_state VALUE={current}
-        {% if current == 1 %}
-            _FILAMENT_SENSOR_EVENT STATE=inserted
-        {% else %}
-            _FILAMENT_SENSOR_EVENT STATE=removed
-        {% endif %}
-    {% endif %}
-    UPDATE_DELAYED_GCODE ID=filament_sensor_watch DURATION=1.0


### PR DESCRIPTION
At a basic level, it does this:

  - enables Klipper’s filament_switch_sensor
  - maps it to the printer’s runout signal on PC0
  - makes the printer report filament present / absent through the normal Klipper sensor path

Make the stock filament sensor available in the config so the printer can detect filament status and use normal runout behavior. This is config only, it does not enable filament run out logic. 