### PR TITLE
Add Z-offset for load cell probe

### DIFF
--- a/meta-opencentauri/recipes-apps/klipper/files/bed.cfg
+++ b/meta-opencentauri/recipes-apps/klipper/files/bed.cfg
@@ -56,5 +56,5 @@ sample_retract_dist: 1.0
 lift_speed: 5.0
 counts_per_gram: 29.11
 reference_tare_counts: 71000
-z_offset: 0.0
+z_offset: -0.15
 trigger_force: 50


### PR DESCRIPTION
## Add factory-calibrated Z-offset for load cell probe

### Description
This PR adds a default `z_offset: -0.15` to the `[load_cell_probe]` of the included config. This value replicates the behaviour of the stock Elegoo firmware.

https://github.com/OpenCentauri/cc-firmware/blob/33e562eb1e973db5a4863037859351b48e4a8a2f/core/klippy/printer_para.cpp#L1912
https://github.com/OpenCentauri/cc-firmware/blob/33e562eb1e973db5a4863037859351b48e4a8a2f/core/klippy/extras/strain_gauge.cpp#L43
https://github.com/OpenCentauri/cc-firmware/blob/33e562eb1e973db5a4863037859351b48e4a8a2f/resources/e100/configs/unmodifiable.cfg#L4
https://github.com/OpenCentauri/cc-firmware/blob/33e562eb1e973db5a4863037859351b48e4a8a2f/core/klippy/extras/bed_mesh.cpp#L325

### Why this change is needed
Because this printer uses the nozzle itself as the probe via the underbed strain gauges, the nozzle must physically press into the build plate to generate enough force to register a trigger. This creates a mechanical discrepancy where the true, un-flexed surface of the bed is actually higher than the coordinate at which Klipper registers the probe trigger. 

This `-0.15mm` offset accounts for:
1. The physical deflection/flex of the bed and hotend required to reach the trigger threshold.
2. Probably some reaction time and processing delay of the HX711s and bed MCU

By applying this `-0.15` offset natively in the standard Klipper config, users should need a far smaller gcode offset and should be less likely to damage their build plates.

This change is going to require any existing bed meshes to be re-done as they are going to bring the nozzle .15mm closer to the bed than intended.

Ideally this change would also be complimented by a mechanism to safely save a gcode offset in a way that remains visible to users in mainsail or fluidd between restarts. I think a safe, slightly high, default wouldn't go amiss here either!