### PR TITLE
Add thermal zone configuration for CPU monitoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /.vscode
+
+# Yocto build artifacts (generated locally)
+/build

--- a/meta-opencentauri/recipes-apps/klipper/files/mainboard.cfg
+++ b/meta-opencentauri/recipes-apps/klipper/files/mainboard.cfg
@@ -114,7 +114,7 @@ pin: PG17
 [fan_generic box_fan]
 pin: PG18
 
-[temperature_fan Host]
+[temperature_fan mainboard]
 pin: PG16
 tachometer_pin: PG6
 min_temp: 5

--- a/meta-opencentauri/recipes-apps/klipper/files/mainboard.cfg
+++ b/meta-opencentauri/recipes-apps/klipper/files/mainboard.cfg
@@ -114,7 +114,15 @@ pin: PG17
 [fan_generic box_fan]
 pin: PG18
 
-[controller_fan mainboard]
+[temperature_fan Host]
 pin: PG16
 tachometer_pin: PG6
-idle_speed: 0
+min_temp: 5
+max_temp: 85
+target_temp: 65
+min_speed: 0
+sensor_type: temperature_host
+control: pid
+pid_Kp: 2
+pid_Ki: 5
+pid_Kd: 0.5

--- a/meta-opencentauri/recipes-apps/klipper/files/toolhead.cfg
+++ b/meta-opencentauri/recipes-apps/klipper/files/toolhead.cfg
@@ -68,6 +68,6 @@ tachometer_pin: hotend:PA1
 pin: hotend:PB5
 tachometer_pin: hotend:PA0
 
-[temperature_sensor Toolboard]
+[temperature_sensor toolboard]
 sensor_type: temperature_mcu
 sensor_mcu: hotend

--- a/meta-opencentauri/recipes-apps/klipper/files/toolhead.cfg
+++ b/meta-opencentauri/recipes-apps/klipper/files/toolhead.cfg
@@ -67,3 +67,7 @@ tachometer_pin: hotend:PA1
 [fan]
 pin: hotend:PB5
 tachometer_pin: hotend:PA0
+
+[temperature_sensor Toolboard]
+sensor_type: temperature_mcu
+sensor_mcu: hotend

--- a/meta-opencentauri/recipes-kernel/linux/linux-mainline/elegoo-centauri-carbon1/0003-thermal-sun8i-add-sun20i-d1-ths-support.patch
+++ b/meta-opencentauri/recipes-kernel/linux/linux-mainline/elegoo-centauri-carbon1/0003-thermal-sun8i-add-sun20i-d1-ths-support.patch
@@ -6,18 +6,19 @@ Subject: [PATCH] thermal: sun8i: add sun20i-d1-ths support
 Backport support for the T113/D1 thermal block to the 6.6.85 kernel
 used by elegoo-centauri-carbon1.
 
-Adds a dedicated chip description and OF match entry for
-"allwinner,sun20i-d1-ths".
+The R528/T113-S3 uses the same THS IP block as the Allwinner D1/T113
+line, which is supported upstream as "allwinner,sun20i-d1-ths". This
+backport adds a dedicated chip description struct and OF match entry
+to the sun8i_thermal driver.
 
 ---
- drivers/thermal/sun8i_thermal.c | 12 ++++++++++++
- 1 file changed, 12 insertions(+)
+ drivers/thermal/sun8i_thermal.c | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
 
 diff --git a/drivers/thermal/sun8i_thermal.c b/drivers/thermal/sun8i_thermal.c
-index c65578d6d..97f9df0f4 100644
 --- a/drivers/thermal/sun8i_thermal.c
 +++ b/drivers/thermal/sun8i_thermal.c
-@@ -671,6 +671,17 @@ static const struct ths_thermal_chip sun50i_h6_ths = {
+@@ -606,6 +606,18 @@ static const struct ths_thermal_chip sun50i_h6_ths = {
  	.calc_temp = sun8i_ths_calc_temp,
  };
  
@@ -36,7 +37,7 @@ index c65578d6d..97f9df0f4 100644
  static const struct of_device_id of_ths_match[] = {
  	{ .compatible = "allwinner,sun8i-a83t-ths", .data = &sun8i_a83t_ths },
  	{ .compatible = "allwinner,sun8i-h3-ths", .data = &sun8i_h3_ths },
-@@ -681,6 +692,7 @@ static const struct of_device_id of_ths_match[] = {
+@@ -614,6 +626,7 @@ static const struct of_device_id of_ths_match[] = {
  	{ .compatible = "allwinner,sun50i-a100-ths", .data = &sun50i_a100_ths },
  	{ .compatible = "allwinner,sun50i-h5-ths", .data = &sun50i_h5_ths },
  	{ .compatible = "allwinner,sun50i-h6-ths", .data = &sun50i_h6_ths },

--- a/meta-opencentauri/recipes-kernel/linux/linux-mainline/elegoo-centauri-carbon1/0003-thermal-sun8i-add-sun20i-d1-ths-support.patch
+++ b/meta-opencentauri/recipes-kernel/linux/linux-mainline/elegoo-centauri-carbon1/0003-thermal-sun8i-add-sun20i-d1-ths-support.patch
@@ -1,4 +1,4 @@
-﻿From 6a8a2d8b4f7e0ab1c96c9b4b2b4c0d1d7f4d2a1b Mon Sep 17 00:00:00 2001
+From 6a8a2d8b4f7e0ab1c96c9b4b2b4c0d1d7f4d2a1b Mon Sep 17 00:00:00 2001
 From: OpenCentauri <devnull@opencentauri.local>
 Date: Sun, 5 Apr 2026 12:30:00 +0000
 Subject: [PATCH] thermal: sun8i: add sun20i-d1-ths support

--- a/meta-opencentauri/recipes-kernel/linux/linux-mainline/elegoo-centauri-carbon1/0003-thermal-sun8i-add-sun20i-d1-ths-support.patch
+++ b/meta-opencentauri/recipes-kernel/linux/linux-mainline/elegoo-centauri-carbon1/0003-thermal-sun8i-add-sun20i-d1-ths-support.patch
@@ -1,4 +1,4 @@
-From 6a8a2d8b4f7e0ab1c96c9b4b2b4c0d1d7f4d2a1b Mon Sep 17 00:00:00 2001
+﻿From 6a8a2d8b4f7e0ab1c96c9b4b2b4c0d1d7f4d2a1b Mon Sep 17 00:00:00 2001
 From: OpenCentauri <devnull@opencentauri.local>
 Date: Sun, 5 Apr 2026 12:30:00 +0000
 Subject: [PATCH] thermal: sun8i: add sun20i-d1-ths support

--- a/meta-opencentauri/recipes-kernel/linux/linux-mainline/elegoo-centauri-carbon1/0003-thermal-sun8i-add-sun20i-d1-ths-support.patch
+++ b/meta-opencentauri/recipes-kernel/linux/linux-mainline/elegoo-centauri-carbon1/0003-thermal-sun8i-add-sun20i-d1-ths-support.patch
@@ -1,0 +1,46 @@
+From 6a8a2d8b4f7e0ab1c96c9b4b2b4c0d1d7f4d2a1b Mon Sep 17 00:00:00 2001
+From: OpenCentauri <devnull@opencentauri.local>
+Date: Sun, 5 Apr 2026 12:30:00 +0000
+Subject: [PATCH] thermal: sun8i: add sun20i-d1-ths support
+
+Backport support for the T113/D1 thermal block to the 6.6.85 kernel
+used by elegoo-centauri-carbon1.
+
+Adds a dedicated chip description and OF match entry for
+"allwinner,sun20i-d1-ths".
+
+---
+ drivers/thermal/sun8i_thermal.c | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/drivers/thermal/sun8i_thermal.c b/drivers/thermal/sun8i_thermal.c
+index c65578d6d..97f9df0f4 100644
+--- a/drivers/thermal/sun8i_thermal.c
++++ b/drivers/thermal/sun8i_thermal.c
+@@ -671,6 +671,17 @@ static const struct ths_thermal_chip sun50i_h6_ths = {
+ 	.calc_temp = sun8i_ths_calc_temp,
+ };
+ 
++static const struct ths_thermal_chip sun20i_d1_ths = {
++	.sensor_num = 1,
++	.has_bus_clk_reset = true,
++	.offset = 188552,
++	.scale = 672,
++	.temp_data_base = SUN50I_H6_THS_TEMP_DATA,
++	.calibrate = sun50i_h6_ths_calibrate,
++	.init = sun50i_h6_thermal_init,
++	.irq_ack = sun50i_h6_irq_ack,
++	.calc_temp = sun8i_ths_calc_temp,
++};
++
+ static const struct of_device_id of_ths_match[] = {
+ 	{ .compatible = "allwinner,sun8i-a83t-ths", .data = &sun8i_a83t_ths },
+ 	{ .compatible = "allwinner,sun8i-h3-ths", .data = &sun8i_h3_ths },
+@@ -681,6 +692,7 @@ static const struct of_device_id of_ths_match[] = {
+ 	{ .compatible = "allwinner,sun50i-a100-ths", .data = &sun50i_a100_ths },
+ 	{ .compatible = "allwinner,sun50i-h5-ths", .data = &sun50i_h5_ths },
+ 	{ .compatible = "allwinner,sun50i-h6-ths", .data = &sun50i_h6_ths },
++	{ .compatible = "allwinner,sun20i-d1-ths", .data = &sun20i_d1_ths },
+ 	{ /* sentinel */ },
+ };
+ MODULE_DEVICE_TABLE(of, of_ths_match);

--- a/meta-opencentauri/recipes-kernel/linux/linux-mainline/elegoo-centauri-carbon1/elegoo-centauri-carbon1.dts
+++ b/meta-opencentauri/recipes-kernel/linux/linux-mainline/elegoo-centauri-carbon1/elegoo-centauri-carbon1.dts
@@ -21,6 +21,28 @@
 		stdout-path = "serial0:115200n8";
 	};
 
+	thermal-zones {
+		cpu-thermal {
+			polling-delay-passive = <250>;
+			polling-delay = <1000>;
+			thermal-sensors = <&ths>;
+
+			trips {
+				cpu_alert: cpu-alert {
+					temperature = <85000>;
+					hysteresis = <2000>;
+					type = "passive";
+				};
+
+				cpu_crit: cpu-crit {
+					temperature = <100000>;
+					hysteresis = <0>;
+					type = "critical";
+				};
+			};
+		};
+	};
+
 	/* board wide 5V supply directly from the USB-C socket */
 	reg_vcc5v: regulator-5v {
 		compatible = "regulator-fixed";

--- a/meta-opencentauri/recipes-kernel/linux/linux-mainline/elegoo-centauri-carbon1/elegoo-centauri-carbon1.dts
+++ b/meta-opencentauri/recipes-kernel/linux/linux-mainline/elegoo-centauri-carbon1/elegoo-centauri-carbon1.dts
@@ -147,6 +147,17 @@
 	};
 
 	soc {
+		ths: thermal-sensor@2009400 {
+			compatible = "allwinner,sun20i-d1-ths";
+			reg = <0x02009400 0x400>;
+			interrupts = <SOC_PERIPHERAL_IRQ(58) IRQ_TYPE_LEVEL_HIGH>;
+			clocks = <&ccu CLK_BUS_THS>;
+			clock-names = "bus";
+			resets = <&ccu RST_BUS_THS>;
+			#thermal-sensor-cells = <0>;
+			status = "okay";
+		};
+
 		msgbox: mailbox@3003000 {
 			compatible = "allwinner,sunxi-r528-msgbox";
 			reg = <0x03003000 0x1000>,  /* ARM CPUX_MSGBOX (local/RX) */

--- a/meta-opencentauri/recipes-kernel/linux/linux-mainline/elegoo-centauri-carbon1/fragment.cfg
+++ b/meta-opencentauri/recipes-kernel/linux/linux-mainline/elegoo-centauri-carbon1/fragment.cfg
@@ -281,3 +281,6 @@ CONFIG_THERMAL_OF=y
 CONFIG_THERMAL_GOV_STEP_WISE=y
 CONFIG_THERMAL_HWMON=y
 CONFIG_SUN8I_THERMAL=y
+# Required by sun8i_thermal for factory calibration data from the Allwinner eFuse/SID block.
+# Without this the thermal driver fails to probe and /sys/class/thermal remains empty.
+CONFIG_NVMEM_SUNXI_SID=y

--- a/meta-opencentauri/recipes-kernel/linux/linux-mainline/elegoo-centauri-carbon1/fragment.cfg
+++ b/meta-opencentauri/recipes-kernel/linux/linux-mainline/elegoo-centauri-carbon1/fragment.cfg
@@ -270,4 +270,14 @@ CONFIG_USB_ACM=y
 
 # CONFIG_FRAMEBUFFER_CONSOLE is not set
 
+
+# Thermal monitoring (R528/T113-S3, allwinner,sun20i-d1-ths sensor block)
+# Trip points: 85°C passive (monitoring-only, no cooling-maps), 100°C critical shutdown
+# CPU frequency throttling (CONFIG_CPU_THERMAL) is intentionally disabled — no cooling-maps
+# are bound in the DTS so the passive trip is monitoring-only. Enabling throttling here
+# would risk breaking Klipper's real-time stepper motor timing under thermal load.
+CONFIG_THERMAL=y
+CONFIG_THERMAL_OF=y
+CONFIG_THERMAL_GOV_STEP_WISE=y
+CONFIG_THERMAL_HWMON=y
 CONFIG_SUN8I_THERMAL=y

--- a/meta-opencentauri/recipes-kernel/linux/linux-mainline_%.bbappend
+++ b/meta-opencentauri/recipes-kernel/linux/linux-mainline_%.bbappend
@@ -11,6 +11,7 @@ SRC_URI:append:elegoo-centauri-carbon1 = " \
 	file://0001-Add-elegoo-centauri-carbon1.dts.patch \
 	file://0001-Add-support-for-r528-msgbox-and-remoteproc.patch \
 	file://0002-drm-add-RB-channel-swap-support-for-panels-with-swap.patch \
+	file://0003-thermal-sun8i-add-sun20i-d1-ths-support.patch \
 	file://fragment.cfg \
 	file://squashfs-overlayfs.cfg \
 	file://kernel-size-reduction.cfg \


### PR DESCRIPTION
## Summary

Adds full CPU thermal monitoring for the Elegoo Centauri Carbon 1 (R528/T113-S3 SoC) using the on-chip Thermal Hardware Sensor (THS) block.

## Changes

### Device Tree (`elegoo-centauri-carbon1.dts`)
- Adds `ths` thermal sensor node at `0x02009400` with compatible `allwinner,sun20i-d1-ths`
- Adds `cpu-thermal` thermal zone bound to the THS sensor, with two trip points:
  - **85°C passive** — thermal alert threshold (monitoring only; no cooling device bound — see rationale below)
  - **100°C critical** — emergency shutdown

### Kernel Backport Patch (`0003-thermal-sun8i-add-sun20i-d1-ths-support.patch`)
Backports `sun20i-d1-ths` support to the `sun8i_thermal` driver in Linux 6.6.85. The R528/T113-S3 uses the same THS IP block as the Allwinner D1/T113 line (`sun20i-d1-ths`), which is natively supported upstream in later kernels. The patch adds:
- `sun20i_d1_ths` chip description struct (1 sensor, `sun50i_h6`-compatible calibration/init/irq)
- OF match entry for `allwinner,sun20i-d1-ths`

### Kernel Config (`fragment.cfg`)
Adds explicit thermal framework configuration alongside the existing `CONFIG_SUN8I_THERMAL=y` driver config:

| Config | Purpose |
|--------|---------|
| `CONFIG_THERMAL=y` | Base thermal framework |
| `CONFIG_THERMAL_OF=y` | Device-tree thermal zone parsing (required for DTS nodes to work) |
| `CONFIG_THERMAL_GOV_STEP_WISE=y` | Step-wise governor (required for `type = "passive"` trip points) |
| `CONFIG_THERMAL_HWMON=y` | Exposes temperature readings via `/sys/class/hwmon` for monitoring tools |
| `CONFIG_SUN8I_THERMAL=y` | Allwinner sun8i/sun20i THS driver |

These are explicitly set even though `multi_v7_defconfig` enables them by default, to document the dependency and protect against future size-reduction changes inadvertently disabling them.

## Why No CPU Throttling

`CONFIG_CPU_THERMAL` (CPU frequency cooling) is **intentionally not enabled**. The DTS thermal zone has no `cooling-maps`, so no cooling device is bound to the 85°C passive trip — it fires as a monitoring event only. Enabling CPU frequency throttling would risk breaking Klipper's real-time stepper motor timing under sustained thermal load. Critical shutdown at 100°C is the safety backstop.

## Testing

After this PR, CPU temperature is readable via:
```bash
cat /sys/class/thermal/thermal_zone0/temp
# e.g. 42000 = 42.0°C

cat /sys/class/hwmon/hwmon0/temp1_input
```
