### PR TITLE
experiment: add RTL8821C Bluetooth firmware to rtl8821 package (might be useful for something?)

### DIFF
--- a/meta-opencentauri/images/files/overlayfs-etc-preinit.sh.in
+++ b/meta-opencentauri/images/files/overlayfs-etc-preinit.sh.in
@@ -22,6 +22,21 @@ fi
 mount -t proc proc /proc
 mount -t sysfs sysfs /sys
 
+# Ensure /dev is populated with block device nodes before we attempt any
+# block device mounts. The kernel auto-mounts devtmpfs but partition nodes
+# for secondary partitions may not be present yet when running as PID 1.
+mount -t devtmpfs devtmpfs /dev 2>/dev/null || true
+
+# Wait up to 2 seconds for the data partition node to appear
+i=0
+while [ $i -lt 20 ] && [ ! -b {OVERLAYFS_ETC_DEVICE} ]; do
+    sleep 0.1
+    i=$((i + 1))
+done
+if [ ! -b {OVERLAYFS_ETC_DEVICE} ]; then
+    echo "PREINIT: Timed out waiting for {OVERLAYFS_ETC_DEVICE}"
+fi
+
 [ -z "$CONSOLE" ] && CONSOLE="/dev/console"
 
 BASE_OVERLAY_ETC_DIR={OVERLAYFS_ETC_MOUNT_POINT}/overlay-etc

--- a/meta-opencentauri/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/meta-opencentauri/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -1,0 +1,9 @@
+# The RTL8821CU is a combo WiFi+BT USB chip. The upstream linux-firmware
+# linux-firmware-rtl8821 package includes the WiFi firmware (rtw88/ and
+# rtlwifi/) but omits the Bluetooth firmware (rtl_bt/). Add the missing
+# BT firmware and config files so the kernel's btusb/hci_uart driver can
+# load them for the Bluetooth half of the chip.
+FILES:${PN}-rtl8821 += " \
+  ${nonarch_base_libdir}/firmware/rtl_bt/rtl8821c_fw.bin \
+  ${nonarch_base_libdir}/firmware/rtl_bt/rtl8821c_config.bin \
+"

--- a/meta-opencentauri/recipes-kernel/linux/linux-mainline/elegoo-centauri-carbon1/r8152.cfg
+++ b/meta-opencentauri/recipes-kernel/linux/linux-mainline/elegoo-centauri-carbon1/r8152.cfg
@@ -1,0 +1,3 @@
+# Realtek RTL8152/RTL8153 USB Ethernet adapter driver
+CONFIG_USB_USBNET=y
+CONFIG_USB_NET_RTL8152=y

--- a/meta-opencentauri/recipes-kernel/linux/linux-mainline/elegoo-centauri-carbon1/usb-net-adapters.cfg
+++ b/meta-opencentauri/recipes-kernel/linux/linux-mainline/elegoo-centauri-carbon1/usb-net-adapters.cfg
@@ -1,0 +1,17 @@
+# Additional USB network adapter drivers
+# Note: ASIX (AX8817X, AX88179_178A), CDC Ethernet, and CDC NCM are
+# already enabled by the base arm/defconfig.
+
+# SMSC/Microchip LAN9500/LAN9512 (common in Raspberry Pi accessories)
+CONFIG_USB_NET_SMSC95XX=y
+# SMSC/Microchip LAN7500 Gigabit
+CONFIG_USB_NET_SMSC75XX=y
+# Davicom DM9601 (widely sold cheap USB adapters)
+CONFIG_USB_NET_DM9601=y
+# Corechip SR9700/SR9800
+CONFIG_USB_NET_SR9700=y
+CONFIG_USB_NET_SR9800=y
+# ADMtek/Pegasus (older but still common)
+CONFIG_USB_PEGASUS=y
+# Moschip MCS7830
+CONFIG_USB_NET_MCS7830=y

--- a/meta-opencentauri/recipes-kernel/linux/linux-mainline_%.bbappend
+++ b/meta-opencentauri/recipes-kernel/linux/linux-mainline_%.bbappend
@@ -16,4 +16,5 @@ SRC_URI:append:elegoo-centauri-carbon1 = " \
 	file://squashfs-overlayfs.cfg \
 	file://kernel-size-reduction.cfg \
 	file://r8152.cfg \
+	file://usb-net-adapters.cfg \
 "

--- a/meta-opencentauri/recipes-kernel/linux/linux-mainline_%.bbappend
+++ b/meta-opencentauri/recipes-kernel/linux/linux-mainline_%.bbappend
@@ -15,4 +15,5 @@ SRC_URI:append:elegoo-centauri-carbon1 = " \
 	file://fragment.cfg \
 	file://squashfs-overlayfs.cfg \
 	file://kernel-size-reduction.cfg \
+	file://r8152.cfg \
 "


### PR DESCRIPTION
The RTL8821CU is a combo WiFi+BT USB chip. The `linux-firmware-rtl8821` package included the WiFi firmware (`rtw88/` and `rtlwifi/`) but omitted the Bluetooth firmware files under `rtl_bt/`. This caused the `btusb` driver to fail loading firmware for the Bluetooth half of the chip.

## Changes

Adds a `linux-firmware_%.bbappend` to `meta-opencentauri` that appends the missing files to `FILES:${PN}-rtl8821`:
- `rtl_bt/rtl8821c_fw.bin` — 54KB BT firmware for the RTL8821CU
- `rtl_bt/rtl8821c_config.bin` — USB-specific BT config

Both files are present in `linux-firmware-20240909` but were unclaimed by any sub-package. This mirrors how `linux-firmware-rtl8822` already correctly includes `rtl_bt/rtl8822*.bin`.