### PR TITLE
Fix webcam links and switch to MJPEG Adaptive

### DIFF
--- a/meta-opencentauri/recipes-apps/moonraker/files/moonraker.conf
+++ b/meta-opencentauri/recipes-apps/moonraker/files/moonraker.conf
@@ -33,5 +33,5 @@ subscriptions:
 
 [webcam webcam]
 service: mjpegstreamer-adaptive
-stream_url: /webcam/stream
-snapshot_url: /webcam/snapshot
+stream_url: /webcam/?action=stream
+snapshot_url: /webcam/?action=snapshot


### PR DESCRIPTION
I'm not sure if Mainsail works out of the box or not, but I use Fluidd and the webcam wasn't loading for me. Changing the URLs and forcing MJPEG Adaptive fixed it for me