### PR TITLE
kalico: fix M112 shutdown leaving outputs latched

### DIFF
--- a/meta-opencentauri/recipes-apps/klipper/kalico_2026.02.00.inc
+++ b/meta-opencentauri/recipes-apps/klipper/kalico_2026.02.00.inc
@@ -5,9 +5,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=1ebbd3e34237af26da5dc08a4e440464"
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 SRC_URI = "git://github.com/OpenCentauri/kalico.git;protocol=https;branch=rpmsg-with-new-hx71x"
-SRCREV = "f66de876fe17b84cfc1401dafebf1260b28e9e6f"
+SRCREV = "afe7178d0859f3cbc80e591473f86ee64183122b"
 
-PR = "r3"
+PR = "r4"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
This updates kalico to the revision that fixes shutdown requests on hifi4.

Previously a shutdown sometimes lead to latched outputs which in turn lead to thermal runaways of the bed.

Refer to https://github.com/OpenCentauri/kalico/commit/afe7178d0859f3cbc80e591473f86ee64183122b