### PR TITLE
Correct second wipe location in WIPE_NOZZLE macro

### DIFF
--- a/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
+++ b/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
@@ -163,16 +163,16 @@ gcode:
 
     # Scrub nozzle back and forth (4 passes)
     G90                             ; Absolute positioning
-    G1 X140 F2000                   ; Scrub right
-    G1 X110                         ; Scrub left
-    G1 X140 F2000                   ; Scrub right
-    G1 X110                         ; Scrub left
-    G1 X140 F2000                   ; Scrub right
-    G1 X110                         ; Scrub left
-    G1 X140 F2000                   ; Scrub right
-    G1 X110                         ; Scrub left
-    G1 X140 F2000                   ; Final scrub right
-    G1 X128                         ; Return to center
+    G1 X187 F2000                   ; Scrub right
+    G1 X173                         ; Scrub left
+    G1 X187 F2000                   ; Scrub right
+    G1 X173                         ; Scrub left
+    G1 X187 F2000                   ; Scrub right
+    G1 X173                         ; Scrub left
+    G1 X187 F2000                   ; Scrub right
+    G1 X173                         ; Scrub left
+    G1 X187 F2000                   ; Final scrub right
+    G1 X173                         ; Return to center
     M400                            ; Wait for completion
 
     # Lift and move away from brush


### PR DESCRIPTION
The M729 macro correctly wipes the nozzle between X173 and X187 where the brush/scrubber is. However in the WIPE_NOZZLE macro the second, slower wipe after touching off on the bed wipes between X110 and X140, where there is nothing to wipe on.

This corrects the second wipe to be in the same location as the first.

I have tested this config on my CC and verified it works as expected.