### PR TITLE
Add M8213 LED On and M8212 LED Off macros for compatibility with the patched firmware gcode

### DIFF
--- a/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
+++ b/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
@@ -5,11 +5,13 @@
 
 # Turn on chamber LED
 [gcode_macro M8213]
-SET_LED LED=case WHITE=1.00 SYNC=0 TRANSMIT=1
+gcode:
+    SET_LED LED=case WHITE=1.00 SYNC=0 TRANSMIT=1
 
 # Turn off chamber LED
 [gcode_macro M8212]
-SET_LED LED=case WHITE=0.00 SYNC=0 TRANSMIT=1
+gcode:
+    SET_LED LED=case WHITE=0.00 SYNC=0 TRANSMIT=1
 
 [gcode_macro _COSMOS_SETTINGS]
 variable_sync_camera_led_to_chamber_led: False

--- a/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
+++ b/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
@@ -7,11 +7,13 @@
 [gcode_macro M8213]
 gcode:
     SET_LED LED=case WHITE=1.00 SYNC=0 TRANSMIT=1
+    SET_LED LED=hotend WHITE=1.00 SYNC=0 TRANSMIT=1
 
 # Turn off chamber LED
 [gcode_macro M8212]
 gcode:
     SET_LED LED=case WHITE=0.00 SYNC=0 TRANSMIT=1
+    SET_LED LED=hotend WHITE=1.00 SYNC=0 TRANSMIT=1
 
 [gcode_macro _COSMOS_SETTINGS]
 variable_sync_camera_led_to_chamber_led: False

--- a/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
+++ b/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
@@ -3,6 +3,14 @@
 # EDITING THIS FILE WILL EXCLUDE YOUR CHANGES FROM FUTURE UPDATES.
 # -----
 
+# Turn on chamber LED
+[gcode_macro M8213]
+SET_LED LED=case WHITE=1.00 SYNC=0 TRANSMIT=1
+
+# Turn off chamber LED
+[gcode_macro M8212]
+SET_LED LED=case WHITE=0.00 SYNC=0 TRANSMIT=1
+
 [gcode_macro _COSMOS_SETTINGS]
 variable_sync_camera_led_to_chamber_led: False
 variable_camera_led_default_on: True


### PR DESCRIPTION
The modified start and end gcode at https://docs.opencentauri.cc/patched-firmware/modified_start_end_machine_gcode/ use M8213 and M8212 gcode for turning on and off the chamber light. Those are not currently implemented in COSMOS so users will see an error if they keep the same gcode they were using for the patched firmware.

This adds the commands back to macros.cfg as aliases to the SET_LED function for compatibility.