### PR TITLE
Add AIC8800 USB WiFi driver

### DIFF
--- a/meta-opencentauri/images/opencentauri-image-base.bb
+++ b/meta-opencentauri/images/opencentauri-image-base.bb
@@ -15,6 +15,7 @@ CORE_IMAGE_EXTRA_INSTALL += "\
     libgpiod-tools \
     kernel-modules \
     rtw88 \
+    aic8800 \
     wpa-supplicant \
     iw \
     kalico \

--- a/meta-opencentauri/recipes-kernel/aic8800/aic8800_git.bb
+++ b/meta-opencentauri/recipes-kernel/aic8800/aic8800_git.bb
@@ -1,0 +1,25 @@
+SUMMARY = "AIC8800 USB WiFi driver"
+DESCRIPTION = "Out-of-tree kernel driver for the AIC8800 chipset."
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://drivers/aic8800/aic8800_fdrv/rwnx_main.c;beginline=1;endline=11;md5=0ed0561fb91deaf3177b5ce8941f51df"
+
+inherit module
+
+SRCREV = "05710dff05dabce66ab3ee80f40484892c512b3c"
+SRC_URI = "git://github.com/shenmintao/aic8800d80.git;protocol=https;branch=main"
+
+S = "${WORKDIR}/git"
+
+EXTRA_OEMAKE += "-C ${STAGING_KERNEL_DIR} M=${S}/drivers/aic8800 \
+    CONFIG_PREALLOC_RX_SKB=n CONFIG_PREALLOC_TXQ=n"
+
+MODULES_MODULE_SYMVERS_LOCATION = "drivers/aic8800"
+
+do_install:append() {
+    install -d ${D}/lib/firmware/aic8800D80
+    install -m 0644 ${S}/fw/aic8800D80/* ${D}/lib/firmware/aic8800D80/
+}
+
+FILES:${PN} += "/lib/firmware/aic8800D80"
+
+COMPATIBLE_MACHINE = "elegoo-centauri-carbon1"

--- a/meta-opencentauri/recipes-kernel/rtw88/files/0001-disable-led-support.patch
+++ b/meta-opencentauri/recipes-kernel/rtw88/files/0001-disable-led-support.patch
@@ -1,29 +1,31 @@
 From 04490ee38aa1ba7118122f6aa1a19eb97c0c0d06 Mon Sep 17 00:00:00 2001
 From: Timo V <timiv@users.noreply.github.com>
 Date: Fri, 6 Mar 2026 01:06:48 +0100
-Subject: [PATCH] Disable LED support (no physical LED on RTL8821CU module)
+Subject: [PATCH] Disable LED, debug and debugfs support
 
 The RTL8821CU USB WiFi adapter on the Elegoo Centauri Carbon 1 has no
 physical LED. Disable CONFIG_RTW88_LEDS to avoid a build dependency on
 CONFIG_LEDS_CLASS which is not enabled in our kernel.
 
-The led.h header provides empty inline stubs when CONFIG_RTW88_LEDS is
-not defined, so the rest of the driver compiles cleanly.
+Also disable CONFIG_RTW88_DEBUG and CONFIG_RTW88_DEBUGFS to reduce RAM
+usage and binary size on an embedded target. The debug.h header provides
+empty inline stubs when these are not defined, so the rest of the driver
+compiles cleanly.
 ---
- Makefile | 2 --
- 1 file changed, 2 deletions(-)
+ Makefile | 4 ----
+ 1 file changed, 4 deletions(-)
 
 diff --git a/Makefile b/Makefile
 index 2a26a06..4fec4bc 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -37,14 +37,12 @@ NO_SKIP_SIGN := y
+@@ -37,14 +37,10 @@ NO_SKIP_SIGN := y
  endif
  
  ccflags-y += -O2 -std=gnu11 -Wno-declaration-after-statement
 -ccflags-y += -DCONFIG_RTW88_LEDS=1
- ccflags-y += -DCONFIG_RTW88_DEBUG=1
- ccflags-y += -DCONFIG_RTW88_DEBUGFS=1
+-ccflags-y += -DCONFIG_RTW88_DEBUG=1
+-ccflags-y += -DCONFIG_RTW88_DEBUGFS=1
  ccflags-y += -D__CHECK_ENDIAN__
  
  obj-m		+= rtw_core.o

--- a/meta-opencentauri/recipes-kernel/rtw88/rtw88_git.bb
+++ b/meta-opencentauri/recipes-kernel/rtw88/rtw88_git.bb
@@ -15,9 +15,6 @@ S = "${WORKDIR}/git"
 
 EXTRA_OEMAKE += "-C ${STAGING_KERNEL_DIR} M=${S}"
 
-# Auto-load the 8821CU module (pulls in rtw_usb, rtw_8821c, rtw_core)
-KERNEL_MODULE_AUTOLOAD += "rtw_8821cu"
-
 # Disable deep power save (RTL8821CU firmware crashes in LPS deep mode)
 KERNEL_MODULE_PROBECONF += "rtw_core"
 module_conf_rtw_core = "options rtw_core disable_lps_deep=Y"


### PR DESCRIPTION
This also modifies the rtw88 driver so that it is not autoloaded, but instead this will be loaded by udev if the usb device is connected.

I have no way to test this so I have no idea if it will work, but i've tested that the kernel module exists and can be loaded, and the firmware is present in the image.