### PR TITLE
Include packagegroup-base-wifi in image

### DIFF
--- a/meta-opencentauri/images/opencentauri-image-base.bb
+++ b/meta-opencentauri/images/opencentauri-image-base.bb
@@ -1,7 +1,11 @@
 DESCRIPTION = "OpenCentauri Base Image"
 LICENSE = "GPL-3.0-only"
 
-IMAGE_INSTALL = "packagegroup-core-boot ${CORE_IMAGE_EXTRA_INSTALL}"
+IMAGE_INSTALL = " \
+    packagegroup-core-boot \
+    packagegroup-base-wifi \
+    ${CORE_IMAGE_EXTRA_INSTALL} \
+"
 
 IMAGE_LINGUAS = " "
 
@@ -16,8 +20,6 @@ CORE_IMAGE_EXTRA_INSTALL += "\
     kernel-modules \
     rtw88 \
     aic8800 \
-    wpa-supplicant \
-    iw \
     kalico \
     moonraker \
     mainsail \


### PR DESCRIPTION
This also pulls in wireless-regdb-static to suppress the warning at boot.

It might be necessary to set the country in `/etc/wpa_supplicant.conf`, for example `country=00` is a global profile, but I'm not sure this will work for 5GHz networks.