### PR TITLE
config-manager: allow helixscreen as screen_ui value

### DIFF
--- a/meta-opencentauri/recipes-data/config-manager/files/config_manager.py
+++ b/meta-opencentauri/recipes-data/config-manager/files/config_manager.py
@@ -3,7 +3,7 @@ import os, configparser, sys
 
 VALIDATORS = {
     'ui': {
-        'screen_ui': ['grumpyscreen', 'guppyscreen', 'atomscreen'],
+        'screen_ui': ['grumpyscreen', 'guppyscreen', 'atomscreen', 'helixscreen'],
         'web_ui': ['mainsail', 'fluidd'],
     },
     'update': {


### PR DESCRIPTION
## Summary

Adds `helixscreen` to the `VALIDATORS['ui']['screen_ui']` allowlist in `config-manager` so it can be selected like the other UIs already shipped in the COSMOS image.

## Background

HelixScreen (https://github.com/prestonbrown/helixscreen) is already packaged as a recipe in this layer at `meta-opencentauri/recipes-apps/helixscreen/` and ships in COSMOS images. However, the boot-time UI selection path is:

```
gui-switcher (S96) → config-manager ui screen_ui → /etc/init.d/<value> start
```

`config-manager`'s hardcoded validator rejects `helixscreen` as an invalid value, deletes it from the parsed config, and falls back to the default (`grumpyscreen`). Net effect: even when an installer or the user sets `screen_ui = helixscreen` in `/etc/klipper/config/cosmos.conf`, the edit is silently dropped at validation time and grumpyscreen launches.

I noticed this while building installer support for HelixScreen on COSMOS. Without this change, the only way to get HelixScreen to auto-launch is to monkey-patch `config-manager` on the device — which is what our installer is currently doing as a workaround.

## Test plan

- [x] On a CC1 running COSMOS, edit `cosmos.conf` to set `screen_ui = helixscreen`
- [x] Confirmed `config-manager ui screen_ui` reports `grumpyscreen` (validator deleted the value) before this change
- [x] After patching `config-manager` to add `helixscreen` to the allowlist, `config-manager ui screen_ui` reports `helixscreen` and `gui-switcher` launches HelixScreen at boot