### PR TITLE
Add filament sensor configuration

### DIFF
--- a/meta-opencentauri/recipes-apps/klipper/files/machine.cfg
+++ b/meta-opencentauri/recipes-apps/klipper/files/machine.cfg
@@ -256,6 +256,11 @@ resolution: 0.5
 
 [exclude_object]
 
+[filament_switch_sensor filament_sensor]
+switch_pin: ^PC0
+pause_on_runout: True
+runout_gcode: PAUSE
+
 [input_shaper]
 damping_ratio_x: 0.06
 damping_ratio_y: 0.082


### PR DESCRIPTION
- Add [filament_switch_sensor] section to machine.cfg
- Uses PC0 pin on main MCU (R528/Allwinner)
- Trigger level: LOW (active when filament is missing)
- Pauses print on filament runout using PAUSE macro

PAUSE macro has to be done properly