### PR TITLE
Revert stock u-boot bootcmd

### DIFF
--- a/meta-opencentauri/recipes-data/update-scripts/files/switch-to-oc-patched
+++ b/meta-opencentauri/recipes-data/update-scripts/files/switch-to-oc-patched
@@ -24,6 +24,9 @@ fi
 # Install firmware
 flash "$SWUFILE"
 
+# Revert stock bootcmd
+fw_setenv bootcmd "run setargs_mmc boot_dsp0 boot_normal"
+
 # Flash stock bootloader
 service klipper stop
 flashtool -d $SERIALPORT_BED -b 250000 -r

--- a/meta-opencentauri/recipes-data/update-scripts/files/switch-to-stock
+++ b/meta-opencentauri/recipes-data/update-scripts/files/switch-to-stock
@@ -45,6 +45,9 @@ unzip "$ZIPFILE" -d /user-resource
 # Install firmware
 flash "$SWUFILE"
 
+# Revert stock bootcmd
+fw_setenv bootcmd "run setargs_mmc boot_dsp0 boot_normal"
+
 # Flash stock bootloader
 flashtool -d $SERIALPORT_BED -b 250000 -r
 flashtool -d $SERIALPORT_BED -f $STOCK_FW_BED -b 115200


### PR DESCRIPTION
After reverting to oc-patched (or stock) the u-boot environment is still dirty from cosmos. It has been observed that something in the elegoo code seems to set the "swu_mode" variable during subsequent updates causing the bootcmd to break. This goes against the assumption that the "swu_mode" is always blank in stock, as it is set to being blank in the stock sw-description file.