### PR TITLE
Fix warning in mainsail for klipper version

### DIFF
--- a/meta-opencentauri/recipes-apps/klipper/kalico_2026.02.00.bb
+++ b/meta-opencentauri/recipes-apps/klipper/kalico_2026.02.00.bb
@@ -75,7 +75,7 @@ do_install() {
 
     # Set our ver
     sed -i 's/APP_NAME = "Kalico"/APP_NAME = "${DISTRO_NAME}"/' ${D}${datadir}/klipper/klippy/__init__.py
-    echo "${DISTRO_VERSION}" > ${D}${datadir}/klipper/klippy/.version
+    echo "Release - ${DISTRO_VERSION}" > ${D}${datadir}/klipper/klippy/.version
 
     # Remove any .pyc files to avoid TMPDIR references
     find ${D} -name '*.pyc' -delete


### PR DESCRIPTION
This "fixes" the warning in mainsail for the version of klipper being too old by "breaking" the semver format. This is irrelavent to us as klipper can't be updated seperatly and informing the user of the cosmos version is more effective.