### PR TITLE
wifi-rescue + usb-ether-rescue: self-healing WiFi + USB-Ethernet fallback

### DIFF
--- a/docs/post-mortems/2026-05-17-wifi-brick.md
+++ b/docs/post-mortems/2026-05-17-wifi-brick.md
@@ -23,7 +23,7 @@ This produced PR #6 ([`docs/research/aic8800.md`](../research/aic8800.md), 171 l
 
 The printer's actual WiFi radio is a Realtek RTL8821CU, not an AIC8800. UART recovery on 2026-05-18 ran `lsusb` for the first time:
 
-```
+```text
 Bus 001 Device 004: ID 0bda:c811 Realtek Semiconductor Corp. 802.11ac NIC
 ```
 
@@ -37,20 +37,20 @@ Two compounding configuration bugs in `/etc/wpa_supplicant.conf` (operator-provi
 
 1. **`GROUP=netdev` on a busybox image with no `netdev` group.** Cosmos 0.0.6 ships a minimal Yocto rootfs without the `netdev` group that desktop distros use. The conf line:
 
-   ```
+   ```ini
    ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
    ```
 
    caused `wpa_supplicant` to fail control-interface initialization with:
 
-   ```
+   ```text
    CTRL: Invalid group 'netdev'
    Failed to initialize control interface 'DIR=/var/run/wpa_supplicant GROUP=netdev'
    ```
 
    `wpa_supplicant` then exited without attempting any association. `wifi-rescue`'s modprobe-cycle was useless because it does not touch the supplicant.
 
-2. **Literal SSID mismatch.** `wpa_supplicant.conf` carried `ssid="Lee Network"` (capital N, no trailing space). The router actually broadcasts `Lee network ` (lowercase n, trailing space  --  verified via `iw dev wlan0 scan` once the supplicant was up). `wpa_supplicant` is strict on literal SSID match; `netsh wlan show networks` on Spambook had normalized the displayed name and hidden the divergence from the operator.
+2. **Literal SSID mismatch.** `wpa_supplicant.conf` carried `ssid="Lee Network"` (capital N, no trailing space). The router actually broadcasts the string `Lee network` followed by one trailing space character (lowercase n; the trailing space is significant and was verified via `iw dev wlan0 scan` once the supplicant was up). `wpa_supplicant` is strict on literal SSID match; `netsh wlan show networks` on Spambook had normalized the displayed name and hidden the divergence from the operator.
 
 After both were fixed via UART shell (`sed -i` to strip the GROUP= clause + rewrite the SSID line) the supplicant came up, associated on the 5 GHz band (RTL8821CU at signal -23 dBm, 433 Mbit/s VHT-MCS 9 80MHz), and progressed to the DHCP-isolation phase that the recovery thread is still working through.
 

--- a/docs/post-mortems/2026-05-17-wifi-brick.md
+++ b/docs/post-mortems/2026-05-17-wifi-brick.md
@@ -1,0 +1,104 @@
+# 2026-05-17 cosmos WiFi brick  --  post-mortem
+
+**Date of brick:** 2026-05-17.
+**Date of recovery:** 2026-05-18 via UART to mainboard J4.
+**Affected unit:** jack-primary's Elegoo Centauri Carbon, cosmos `0.0.6` build (`fedcf64` / May 16 SWU).
+**Severity:** unit LAN-unreachable; touchscreen WiFi spinner indefinitely; revert blocked because kalico had already been flashed to the bed MCU (Class 217).
+
+## Symptoms
+
+- Touchscreen renders normally; WiFi screen shows endless connect spinner.
+- Configured "Lee Network" SSID never appears in the touchscreen WiFi list.
+- Printer not at its historical LAN IP; not reachable from any subnet host.
+- About panel empty (Moonraker unreachable).
+- Standard recovery via `usb-mount` + `emergency.swu` stock-rollback failed at `restore-mcu-firmware` because kalico was on the bed MCU (Class 217 anchor; this part was correctly diagnosed at the time).
+
+## Misdiagnosis path
+
+For ~24 hours the working hypothesis was: AIC8800 driver bind failure matching upstream issue [shenmintao/aic8800d80#46](https://github.com/shenmintao/aic8800d80/issues/46) (a known firmware-load timing race where `aic_load_fw` fails to open `/lib/firmware/aic8800D80/fmacfw_8800d80_u02.bin` at boot, fixable by manual `modprobe -r aic8800_fdrv && modprobe aic8800_fdrv`).
+
+This produced PR #6 ([`docs/research/aic8800.md`](../research/aic8800.md), 171 lines) cataloguing four candidate fixes (A defer auto-load, B driver patch, C firmware-readable pre-flight in `wifi-rescue`, D `CONFIG_FW_LOADER_USER_HELPER` + udev). All anchored against the upstream issue. All speculative pending dmesg from the bricked unit.
+
+### Why the AIC8800 anchor was wrong
+
+The printer's actual WiFi radio is a Realtek RTL8821CU, not an AIC8800. UART recovery on 2026-05-18 ran `lsusb` for the first time:
+
+```
+Bus 001 Device 004: ID 0bda:c811 Realtek Semiconductor Corp. 802.11ac NIC
+```
+
+Driver loaded for it: `rtw_8821cu`. Cosmos ships `meta-opencentauri/recipes-kernel/rtw88/rtw88_git.bb` for exactly this case.
+
+`aic8800_fdrv` was ALSO loaded (cosmos ships it for other Centauri Carbon SKUs that DO carry AIC8800). The naive `lsmod | grep -iE 'aic|rtw|wlan'` view from the bench-side debugging chain showed `aic8800_fdrv` listed, which got mistaken for the active radio driver. Nobody ran `lsusb` against the printer to identify the chip by VID:PID. Class 218 ("Load Hardware Specs Before Physical Instruction") was already banked at this point; the lesson didn't apply itself because the recognition signals enumerated wiring / pin / connector contexts, not "name a driver from the running fleet's debug telemetry."
+
+## Actual root cause
+
+Two compounding configuration bugs in `/etc/wpa_supplicant.conf` (operator-provisioned during initial Marlindog WiFi setup, then shipped unchanged into the cosmos image build's `/etc`):
+
+1. **`GROUP=netdev` on a busybox image with no `netdev` group.** Cosmos 0.0.6 ships a minimal Yocto rootfs without the `netdev` group that desktop distros use. The conf line:
+
+   ```
+   ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
+   ```
+
+   caused `wpa_supplicant` to fail control-interface initialization with:
+
+   ```
+   CTRL: Invalid group 'netdev'
+   Failed to initialize control interface 'DIR=/var/run/wpa_supplicant GROUP=netdev'
+   ```
+
+   `wpa_supplicant` then exited without attempting any association. `wifi-rescue`'s modprobe-cycle was useless because it does not touch the supplicant.
+
+2. **Literal SSID mismatch.** `wpa_supplicant.conf` carried `ssid="Lee Network"` (capital N, no trailing space). The router actually broadcasts `Lee network ` (lowercase n, trailing space  --  verified via `iw dev wlan0 scan` once the supplicant was up). `wpa_supplicant` is strict on literal SSID match; `netsh wlan show networks` on Spambook had normalized the displayed name and hidden the divergence from the operator.
+
+After both were fixed via UART shell (`sed -i` to strip the GROUP= clause + rewrite the SSID line) the supplicant came up, associated on the 5 GHz band (RTL8821CU at signal -23 dBm, 433 Mbit/s VHT-MCS 9 80MHz), and progressed to the DHCP-isolation phase that the recovery thread is still working through.
+
+## Recovery path that worked
+
+1. DSD TECH SH-U09C5 USB-to-TTL adapter (FTDI FT232RL, multi-voltage) into Belkin powered hub on pono-pi.
+2. Adapter wired to mainboard J4 (right-side 4-pin 2.54mm header; pin 1 GND square pad, pin 2 TX, pin 3 RX, pin 4 5V leave open). Voltage verified at 3.3V on TX-to-GND with a multimeter before connecting.
+3. Power on printer; arm `screen /dev/ttyUSB0 115200` on pono-pi.
+4. Cosmos booted cleanly to a `cosmos login:` prompt. Linux kernel, klipper, moonraker, grumpyscreen, ustreamer all started normally.
+5. Logged in as `root` (no password), read `/data/wifi-rescue.log` → found the `Invalid group 'netdev'` error.
+6. `lsusb` → identified the actual chip (RTL8821CU, not AIC8800).
+7. `iw dev wlan0 scan` → revealed the SSID literal mismatch.
+8. Fixed both in `/etc/wpa_supplicant.conf`, restarted networking, association succeeded.
+
+Subsequent DHCP / mesh-routing issues are downstream of the root-cause fix and being worked through in real time.
+
+## What was wrong with the diagnosis chain
+
+| Failure | Consequence | Pre-emptive control |
+|---|---|---|
+| `lsmod`-only WiFi driver identification (Maui never ran `lsusb` on the printer) | 24h of upstream-issue-#46 spelunking on the wrong chip | Class 218 recognition signal extension: "before naming the WiFi driver, run `lsusb` and grep for known wireless VIDs (`0bda` Realtek, `0e8d` MediaTek, `148f` Ralink, `a69c` AIC8800, `0cf3` Atheros, `2357` TP-Link, `13b1` Linksys)" |
+| Assumed `wpa_supplicant.conf` was healthy without ever reading it | All effort spent on driver layer; the supplicant was failing at init | Class 218 recognition signal extension: when the symptom is "WiFi does not associate" and the driver is loaded, read `wpa_supplicant.conf` + supplicant log BEFORE any kernel-side investigation |
+| Trusted `netsh wlan show networks` SSID display as canonical | SSID-literal mismatch hidden by Windows's display normalization | Anchor against the AP's beacon directly (`iw scan`, `wpa_cli scan_results`) when configuring `wpa_supplicant` |
+| `wifi-rescue` script could not auto-heal a config bug | The script ran S80 on every boot, detected interface absent, modprobe-cycled, gave up. The supplicant-init error never triggered any compensating action | wifi-rescue commit [fa28c17](../../meta-opencentauri/recipes-core/wifi-rescue/files/wifi-rescue): add `validate_wpa_group()` pre-check that strips GROUP= when the named group is absent. Defensive + reversible (backup at `<conf>.broken-group-<name>-stripped`) |
+| `WIFI_RESCUE_USB_VENDORS` default was `a69c` only | USB unbind/rebind branch could not reach the Realtek radio if it ever became the failure surface | wifi-rescue commit [fa28c17](../../meta-opencentauri/recipes-core/wifi-rescue/files/wifi-rescue-default): default extended to `a69c 0bda` |
+
+## What the cosmos source got right
+
+- `wifi-rescue` ALREADY listed `rtw_8821cu` in `WIFI_RESCUE_DRIVERS` (line 17). The driver-reload chain would have tried it. It did not fix anything because the failure was upstream of any driver concern.
+- `meta-opencentauri/recipes-kernel/rtw88/rtw88_git.bb` exists; RTL8821CU support is intentional.
+- Class 217 closure work (PRs #3 / #4) already gated `restore-mcu-firmware` and `update-cosmos` correctly for the kalico-on-MCU substrate; that part of the brick (the revert-path blockage) was independently real and remains correctly diagnosed.
+
+## What the cosmos source still gets wrong (open items)
+
+- `wifi-rescue` does not detect literal SSID mismatch as a failure mode. It cannot safely auto-fix this (rewriting the SSID is destructive without operator intent), but it could log a loud warning when `wpa_cli scan_results` shows a strong AP whose SSID differs only in case/whitespace from the configured SSID. Filed implicit; not shipped this pass.
+- `wpa_supplicant.conf` validation could move further upstream: a pre-flight at first boot that sanity-checks the config (group existence, SSID-vs-scan-results sanity if WiFi is up briefly) and writes findings to `/var/log/wpa-config-validate.log`. Larger scope; not shipped.
+- Operator-side: there is no tooling to validate a `wpa_supplicant.conf` BEFORE flashing it into a SWU. The shipped conf came from an upstream cosmos image that had been built on a desktop distro with the `netdev` group; the cosmos image build did not catch the mismatch.
+
+## Cross-references
+
+- [Class 217](../lessons/class-217-revert-paths-must-survive-substrate.md)  --  still valid for the revert-path-blocked side of the brick (kalico-on-MCU). Not the same failure as this post-mortem covers.
+- [Class 218](../lessons/class-218-load-specs-before-physical-instruction.md)  --  instance #2 banked from this misdiagnosis. The original instance (2026-05-17, ~3h of rear-panel UART wire-mapping) was hardware-pin specific; this instance extends recognition signals to "naming a driver from `lsmod` rather than `lsusb`."
+- [docs/research/aic8800.md](../research/aic8800.md)  --  preserved as reference research for Centauri Carbon SKUs that DO ship AIC8800. Now carries a CORRECTION banner pointing at this post-mortem.
+- [docs/recovery.md](../recovery.md)  --  operator decision tree. Branch A (USB-Ethernet for WiFi-dead) was the right design but assumed reachable rootfs without a working WiFi config; this post-mortem shows the additional supplicant-config failure mode.
+
+## Provenance
+
+- Recovery thread: parallel session 2026-05-18 evening, UART captures + diagnostic sweeps via pyserial.
+- Author of this post-mortem: Maui (audit thread, same date), anchored against the parallel-thread findings and the cosmos source at s-plus-batch `fa28c17`.
+- Original brick handoff: [`HANDOFF-COSMOS-V4-2026-05-17.md`](../../HANDOFF-COSMOS-V4-2026-05-17.md) at the Brofalo working tree root (Pono-side note, not in the cosmos repo).
+- Original brick memory: `feedback_cosmos_brick_post_mortem_2026_05_17.md` in the Pono memory dir (now carries a CORRECTION-2026-05-18 banner cross-referencing this doc).

--- a/meta-opencentauri/images/opencentauri-image-base.bb
+++ b/meta-opencentauri/images/opencentauri-image-base.bb
@@ -43,6 +43,9 @@ CORE_IMAGE_EXTRA_INSTALL += "\
     v4l-utils \
     iproute2 \
     chrony \
+    hardware-scan \
+    wifi-rescue \
+    usb-ether-rescue \
 "
 
 INITRAMFS_IMAGE = "core-image-tiny-initramfs"

--- a/meta-opencentauri/images/opencentauri-image-base.bb
+++ b/meta-opencentauri/images/opencentauri-image-base.bb
@@ -46,6 +46,7 @@ CORE_IMAGE_EXTRA_INSTALL += "\
     hardware-scan \
     wifi-rescue \
     usb-ether-rescue \
+    cosmos-disk-recovery \
 "
 
 INITRAMFS_IMAGE = "core-image-tiny-initramfs"

--- a/meta-opencentauri/recipes-core/cosmos-disk-recovery/cosmos-disk-recovery_1.0.bb
+++ b/meta-opencentauri/recipes-core/cosmos-disk-recovery/cosmos-disk-recovery_1.0.bb
@@ -1,0 +1,65 @@
+# Class 217 recovery path: offline / USB-thumb-drive SWU flash surface.
+#
+# When neither WiFi (wifi-rescue) nor USB-Ethernet (usb-ether-rescue)
+# can bring the network up, the operator's last recovery surface is a
+# local SWU file. Cosmos already has the network-based surface in
+# update-scripts (switch-to-stock and switch-to-oc-patched, both of
+# which curl an SWU from a public URL). This recipe adds the OFFLINE
+# peer to those: flash an SWU that is already on disk or on an
+# inserted USB thumb drive, with no network or DNS dependency.
+#
+# Two source paths supported:
+#   1. Locally cached SWUs at /data/recovery/{oc,stock}-restore.swu.
+#      Operator provisions via USB or scp once; subsequent restores
+#      no longer need the USB stick.
+#   2. SWUs on an inserted USB thumb drive at /tmp/usb/*/<name>.swu.
+#      Reuses the existing usb-automount mount point; does NOT touch
+#      the emergency.swu auto-flash path that usb-automount already
+#      owns. Operator-named files only, operator-invoked (no auto
+#      flash on hot-plug to keep the foot-gun closed).
+#
+# Companion to wifi-rescue + usb-ether-rescue + hardware-scan: those
+# three keep the network surface alive; this one survives the case
+# where they cannot.
+
+SUMMARY = "Offline SWU flash from local disk or USB thumb drive"
+DESCRIPTION = "Operator-invoked recovery flash from /data/recovery/ or \
+inserted USB-mounted SWUs. Companion to switch-to-stock / \
+switch-to-oc-patched: same flash primitives, no network required."
+HOMEPAGE = "https://github.com/Brofalo/pono-print-cosmos"
+LICENSE = "GPL-3.0-only"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-3.0-only;md5=c79ff39f19dfec6d293b95dea7b07891"
+
+SRC_URI = "\
+    file://cosmos-disk-recovery-init-d \
+    file://cosmos-disk-recovery \
+    file://cosmos-disk-recovery-default \
+"
+
+S = "${WORKDIR}"
+
+RDEPENDS:${PN} = "swu-flasher swupdate"
+
+inherit update-rc.d
+
+INITSCRIPT_NAME = "cosmos-disk-recovery"
+# After local-fs mounts settle (so /data is visible) but before user
+# services need ready state. Stop early on shutdown.
+INITSCRIPT_PARAMS = "defaults 88 12"
+
+do_install() {
+    install -d ${D}${sysconfdir}/init.d
+    install -m 0755 ${WORKDIR}/cosmos-disk-recovery-init-d ${D}${sysconfdir}/init.d/cosmos-disk-recovery
+
+    install -d ${D}${sbindir}
+    install -m 0755 ${WORKDIR}/cosmos-disk-recovery ${D}${sbindir}/cosmos-disk-recovery
+
+    install -d ${D}${sysconfdir}/default
+    install -m 0644 ${WORKDIR}/cosmos-disk-recovery-default ${D}${sysconfdir}/default/cosmos-disk-recovery
+}
+
+FILES:${PN} = "\
+    ${sysconfdir}/init.d/cosmos-disk-recovery \
+    ${sysconfdir}/default/cosmos-disk-recovery \
+    ${sbindir}/cosmos-disk-recovery \
+"

--- a/meta-opencentauri/recipes-core/cosmos-disk-recovery/cosmos-disk-recovery_1.0.bb
+++ b/meta-opencentauri/recipes-core/cosmos-disk-recovery/cosmos-disk-recovery_1.0.bb
@@ -38,7 +38,7 @@ SRC_URI = "\
 
 S = "${WORKDIR}"
 
-RDEPENDS:${PN} = "swu-flasher swupdate"
+RDEPENDS:${PN} = "swu-flasher swupdate update-scripts"
 
 inherit update-rc.d
 

--- a/meta-opencentauri/recipes-core/cosmos-disk-recovery/files/cosmos-disk-recovery
+++ b/meta-opencentauri/recipes-core/cosmos-disk-recovery/files/cosmos-disk-recovery
@@ -1,0 +1,352 @@
+#!/bin/sh
+# cosmos-disk-recovery: offline SWU flash from /data/recovery/ or USB.
+#
+# Companion to wifi-rescue + usb-ether-rescue + hardware-scan. When
+# the network surface stays dead, this is the last recovery lane.
+# Reuses cosmos primitives: restore-mcu-firmware, flash, uiprompt,
+# fw_setenv. No network calls, no curl, no DNS lookups.
+#
+# Usage:
+#   cosmos-disk-recovery scan-usb
+#     List SWU candidates on currently-mounted USB drives at /tmp/usb/*.
+#
+#   cosmos-disk-recovery restore-oc [<path>]
+#     Flash an OC-patched SWU. Defaults to /data/recovery/oc-restore.swu;
+#     can take an explicit <path> (e.g. /tmp/usb/sda1/oc-restore.swu)
+#     or fall back to scanning USB drives for the default filename.
+#     Does not touch the bed MCU bootloader unless the SWU embeds
+#     dsp0_partition (the stock-bootloader signature).
+#
+#   cosmos-disk-recovery restore-stock [<path>]
+#     Flash a stock OC SWU. Defaults to /data/recovery/stock-restore.swu.
+#     Always calls restore-mcu-firmware before flash (matches the
+#     upstream switch-to-stock behavior; stock mode wants the bed MCU
+#     reset regardless of the SWU's signature). Resets u-boot bootcmd
+#     to the stock sequence after flash so the printer comes back up
+#     on stock.
+#
+#   cosmos-disk-recovery validate <path>
+#     Sanity-check an SWU without flashing: file present, size above
+#     the 1 MiB floor. Returns 0 if valid, non-zero with a reason if not.
+#
+#   cosmos-disk-recovery status
+#     Print whether /data/recovery/{oc,stock}-restore.swu exist and
+#     pass validation.
+
+set -u
+
+COSMOS_DISK_RECOVERY_ENABLED="${COSMOS_DISK_RECOVERY_ENABLED:-1}"
+COSMOS_DISK_RECOVERY_LOG="${COSMOS_DISK_RECOVERY_LOG:-/var/log/cosmos-disk-recovery.log}"
+COSMOS_DISK_RECOVERY_DIR="${COSMOS_DISK_RECOVERY_DIR:-/data/recovery}"
+COSMOS_DISK_RECOVERY_OC_NAME="${COSMOS_DISK_RECOVERY_OC_NAME:-oc-restore.swu}"
+COSMOS_DISK_RECOVERY_STOCK_NAME="${COSMOS_DISK_RECOVERY_STOCK_NAME:-stock-restore.swu}"
+COSMOS_DISK_RECOVERY_MIN_BYTES="${COSMOS_DISK_RECOVERY_MIN_BYTES:-1048576}"
+COSMOS_DISK_RECOVERY_USB_ROOT="${COSMOS_DISK_RECOVERY_USB_ROOT:-/tmp/usb}"
+
+if [ -r /etc/default/cosmos-disk-recovery ]; then
+    # shellcheck disable=SC1091
+    . /etc/default/cosmos-disk-recovery
+fi
+
+if [ "${COSMOS_DISK_RECOVERY_ENABLED}" != "1" ]; then
+    echo "cosmos-disk-recovery: disabled via COSMOS_DISK_RECOVERY_ENABLED=0" >&2
+    exit 0
+fi
+
+mkdir -p "$(dirname "${COSMOS_DISK_RECOVERY_LOG}")" 2>/dev/null || true
+
+log() {
+    msg="[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"
+    if ! echo "${msg}" >>"${COSMOS_DISK_RECOVERY_LOG}" 2>/dev/null; then
+        echo "${msg}" >&2
+    fi
+    echo "${msg}" >&2
+}
+
+ui_say() {
+    # Best-effort touchscreen prompt; the existing usb-mount path uses
+    # uiprompt + uiclear for the same role. Failures are non-fatal so
+    # the operator UART / SSH workflow keeps working when grumpyscreen
+    # is down.
+    if command -v uiprompt >/dev/null 2>&1; then
+        uiprompt "$1" "$2" >/dev/null 2>&1 || true
+    fi
+}
+
+ui_clear() {
+    if command -v uiclear >/dev/null 2>&1; then
+        uiclear >/dev/null 2>&1 || true
+    fi
+}
+
+swu_exists() {
+    [ -n "$1" ] && [ -f "$1" ]
+}
+
+swu_size_ok() {
+    path="$1"
+    [ -f "${path}" ] || return 1
+    size=""
+    if command -v stat >/dev/null 2>&1; then
+        size="$(stat -c %s "${path}" 2>/dev/null || echo 0)"
+    fi
+    if [ -z "${size}" ] || [ "${size}" = "0" ]; then
+        # BusyBox without stat or stat failed: fall back to wc -c.
+        size="$(wc -c < "${path}" 2>/dev/null || echo 0)"
+    fi
+    [ "${size}" -ge "${COSMOS_DISK_RECOVERY_MIN_BYTES}" ]
+}
+
+swu_has_dsp0() {
+    # The cosmos / stock bootloader SWUs embed a "dsp0_partition" string
+    # in their metadata. usb-mount uses the same probe to decide whether
+    # to invoke restore-mcu-firmware before flashing; mirror that here
+    # so the OFFLINE recovery surface treats stock SWUs the same way
+    # the existing USB recovery surface does.
+    path="$1"
+    [ -f "${path}" ] || return 1
+    strings "${path}" 2>/dev/null | grep -qx "dsp0_partition"
+}
+
+validate_swu() {
+    path="$1"
+    if ! swu_exists "${path}"; then
+        log "validate: ${path} not present"
+        return 2
+    fi
+    if ! swu_size_ok "${path}"; then
+        log "validate: ${path} below ${COSMOS_DISK_RECOVERY_MIN_BYTES} byte sanity floor"
+        return 3
+    fi
+    # We do not gate on dsp0_partition here because OC-patched SWUs are
+    # legitimate and do not carry it; that signature only matters at
+    # flash time to decide whether restore-mcu-firmware should run.
+    log "validate: ${path} OK"
+    return 0
+}
+
+flash_swu() {
+    path="$1"
+    mode="$2"
+
+    if ! validate_swu "${path}"; then
+        log "abort: validate failed for ${path}"
+        return 1
+    fi
+
+    has_dsp0=0
+    if swu_has_dsp0 "${path}"; then
+        has_dsp0=1
+    fi
+
+    log "flash: starting (mode=${mode}, has_dsp0=${has_dsp0}, path=${path})"
+    ui_say "Restoring firmware" "Flashing ${path}, do not power off..."
+
+    if [ "${mode}" = "stock" ] || [ "${has_dsp0}" -eq 1 ]; then
+        if command -v restore-mcu-firmware >/dev/null 2>&1; then
+            log "flash: invoking restore-mcu-firmware"
+            if ! restore-mcu-firmware >>"${COSMOS_DISK_RECOVERY_LOG}" 2>&1; then
+                log "flash: restore-mcu-firmware returned non-zero; aborting"
+                ui_say "Restore failed" "restore-mcu-firmware returned non-zero; check logs."
+                return 2
+            fi
+        else
+            log "flash: restore-mcu-firmware not on PATH; cannot proceed with stock flow"
+            ui_say "Restore failed" "restore-mcu-firmware tool missing."
+            return 2
+        fi
+    fi
+
+    if ! command -v flash >/dev/null 2>&1; then
+        log "flash: 'flash' tool not on PATH; cannot proceed"
+        ui_say "Restore failed" "Flash tool missing; check installation."
+        return 3
+    fi
+
+    log "flash: invoking flash ${path}"
+    if ! flash "${path}" >>"${COSMOS_DISK_RECOVERY_LOG}" 2>&1; then
+        log "flash: flash returned non-zero; aborting"
+        ui_say "Restore failed" "Flash returned non-zero; check logs."
+        return 4
+    fi
+
+    if [ "${mode}" = "stock" ]; then
+        # switch-to-stock resets bootcmd back to the stock boot
+        # sequence after flash. Mirror that here so the rebooted
+        # printer comes up on the stock bootloader path.
+        if command -v fw_setenv >/dev/null 2>&1; then
+            log "flash: resetting bootcmd to stock"
+            fw_setenv bootcmd "run setargs_mmc boot_dsp0 boot_normal" \
+                >>"${COSMOS_DISK_RECOVERY_LOG}" 2>&1 || \
+                log "flash: fw_setenv bootcmd failed (continuing)"
+        else
+            log "flash: fw_setenv not on PATH; bootcmd unchanged (operator may need to reset manually)"
+        fi
+    fi
+
+    log "flash: complete (mode=${mode})"
+    ui_clear
+    ui_say "Firmware restored" "Reboot to finalize."
+    return 0
+}
+
+resolve_swu() {
+    explicit="$1"
+    cache_default="$2"
+    if [ -n "${explicit}" ]; then
+        if swu_exists "${explicit}"; then
+            echo "${explicit}"
+            return 0
+        fi
+        # Explicit path given but file is absent. Do not fall back to
+        # cache or USB scan; the operator was explicit, surface the
+        # error.
+        return 1
+    fi
+    if swu_exists "${cache_default}"; then
+        echo "${cache_default}"
+        return 0
+    fi
+    # Fall back to scanning USB drives in mount order. We look for the
+    # exact basename of the cache default so the operator's intent
+    # carries across (oc vs stock is set by the calling subcommand).
+    base="$(basename "${cache_default}")"
+    for dir in "${COSMOS_DISK_RECOVERY_USB_ROOT}"/*; do
+        [ -d "${dir}" ] || continue
+        candidate="${dir}/${base}"
+        if swu_exists "${candidate}"; then
+            echo "${candidate}"
+            return 0
+        fi
+    done
+    return 1
+}
+
+cmd_scan_usb() {
+    found=0
+    for dir in "${COSMOS_DISK_RECOVERY_USB_ROOT}"/*; do
+        [ -d "${dir}" ] || continue
+        log "scan-usb: checking ${dir}"
+        for name in \
+            "${COSMOS_DISK_RECOVERY_OC_NAME}" \
+            "${COSMOS_DISK_RECOVERY_STOCK_NAME}" \
+            cosmos-recovery.swu \
+            recovery.swu
+        do
+            cand="${dir}/${name}"
+            if swu_exists "${cand}"; then
+                if swu_size_ok "${cand}"; then
+                    if swu_has_dsp0 "${cand}"; then
+                        log "  found: ${cand} (size OK, dsp0_partition present, stock flow)"
+                    else
+                        log "  found: ${cand} (size OK, no dsp0_partition, OC flow)"
+                    fi
+                    found=$((found + 1))
+                else
+                    log "  found: ${cand} (size below sanity floor; skipping)"
+                fi
+            fi
+        done
+    done
+    if [ "${found}" -eq 0 ]; then
+        log "scan-usb: no candidates found"
+        return 1
+    fi
+    log "scan-usb: ${found} candidate(s) total"
+    return 0
+}
+
+cmd_restore_oc() {
+    explicit="${1:-}"
+    cache_default="${COSMOS_DISK_RECOVERY_DIR}/${COSMOS_DISK_RECOVERY_OC_NAME}"
+    resolved="$(resolve_swu "${explicit}" "${cache_default}")"
+    if [ -z "${resolved}" ]; then
+        log "restore-oc: no SWU found (cache ${cache_default}, no USB candidates)"
+        ui_say "Restore failed" "No OC SWU at ${cache_default}."
+        return 2
+    fi
+    log "restore-oc: using ${resolved}"
+    flash_swu "${resolved}" "oc"
+}
+
+cmd_restore_stock() {
+    explicit="${1:-}"
+    cache_default="${COSMOS_DISK_RECOVERY_DIR}/${COSMOS_DISK_RECOVERY_STOCK_NAME}"
+    resolved="$(resolve_swu "${explicit}" "${cache_default}")"
+    if [ -z "${resolved}" ]; then
+        log "restore-stock: no SWU found (cache ${cache_default}, no USB candidates)"
+        ui_say "Restore failed" "No stock SWU at ${cache_default}."
+        return 2
+    fi
+    log "restore-stock: using ${resolved}"
+    flash_swu "${resolved}" "stock"
+}
+
+cmd_validate() {
+    if [ -z "${1:-}" ]; then
+        echo "Usage: cosmos-disk-recovery validate <path>" >&2
+        return 1
+    fi
+    validate_swu "$1"
+}
+
+cmd_status() {
+    for tag in oc stock; do
+        case "${tag}" in
+            oc) name="${COSMOS_DISK_RECOVERY_OC_NAME}" ;;
+            stock) name="${COSMOS_DISK_RECOVERY_STOCK_NAME}" ;;
+            *) continue ;;
+        esac
+        path="${COSMOS_DISK_RECOVERY_DIR}/${name}"
+        if swu_exists "${path}"; then
+            if validate_swu "${path}" >/dev/null 2>&1; then
+                echo "${tag}: present, valid (${path})"
+            else
+                echo "${tag}: present, invalid (${path})"
+            fi
+        else
+            echo "${tag}: absent (${path})"
+        fi
+    done
+}
+
+case "${1:-help}" in
+    scan-usb)
+        cmd_scan_usb
+        ;;
+    restore-oc)
+        cmd_restore_oc "${2:-}"
+        ;;
+    restore-stock)
+        cmd_restore_stock "${2:-}"
+        ;;
+    validate)
+        cmd_validate "${2:-}"
+        ;;
+    status)
+        cmd_status
+        ;;
+    help|--help|-h|"")
+        cat <<'USAGE'
+Usage: cosmos-disk-recovery <command> [args]
+
+Commands:
+  scan-usb               List SWU candidates on mounted USB drives.
+  restore-oc [<path>]    Flash an OC-patched SWU. Default source:
+                         /data/recovery/oc-restore.swu.
+  restore-stock [<path>] Flash a stock OC SWU. Default source:
+                         /data/recovery/stock-restore.swu.
+  validate <path>        Sanity-check an SWU without flashing.
+  status                 Report presence + validity of cached SWUs.
+
+Companion to wifi-rescue + usb-ether-rescue. Use when the network
+surface is dead. After flash, reboot to activate. See man-page-style
+header at the top of /usr/sbin/cosmos-disk-recovery for details.
+USAGE
+        ;;
+    *)
+        echo "cosmos-disk-recovery: unknown command '$1'." >&2
+        echo "Run 'cosmos-disk-recovery help' for usage." >&2
+        exit 1
+        ;;
+esac

--- a/meta-opencentauri/recipes-core/cosmos-disk-recovery/files/cosmos-disk-recovery-default
+++ b/meta-opencentauri/recipes-core/cosmos-disk-recovery/files/cosmos-disk-recovery-default
@@ -1,0 +1,36 @@
+# /etc/default/cosmos-disk-recovery -- runtime config for the offline
+# SWU recovery surface.
+#
+# Override defaults here; cosmos-disk-recovery sources this file at
+# startup if present.
+
+# Master switch. Set to 0 to disable; the cosmos-disk-recovery script
+# exits cleanly without scanning or flashing. Useful when reproducing
+# a defect against the stock recovery surface only.
+COSMOS_DISK_RECOVERY_ENABLED=1
+
+# Where to log actions.
+COSMOS_DISK_RECOVERY_LOG=/var/log/cosmos-disk-recovery.log
+
+# Where cached recovery SWUs live. The init.d script creates this
+# directory at boot if missing.
+COSMOS_DISK_RECOVERY_DIR=/data/recovery
+
+# Default SWU filenames. The OC variant is the OC-patched / cosmos
+# build the operator wants to return to; the stock variant is the
+# Elegoo-shipped firmware. scan-usb also probes a couple of generic
+# fallback names (cosmos-recovery.swu, recovery.swu) so an operator
+# with a non-standard naming convention still gets a hit.
+COSMOS_DISK_RECOVERY_OC_NAME=oc-restore.swu
+COSMOS_DISK_RECOVERY_STOCK_NAME=stock-restore.swu
+
+# Minimum SWU size in bytes. Anything below this is rejected as
+# truncated or wrong-file-type. 1 MiB is well under any real cosmos
+# SWU (about 150 to 300 MiB typical) and well above empty / tiny
+# garbage. Lower if you intentionally ship a tiny test SWU.
+COSMOS_DISK_RECOVERY_MIN_BYTES=1048576
+
+# Where USB drives are mounted by the existing usb-automount recipe.
+# We never mount or unmount here; we only read from already-mounted
+# partitions to avoid racing usb-mount's own emergency.swu path.
+COSMOS_DISK_RECOVERY_USB_ROOT=/tmp/usb

--- a/meta-opencentauri/recipes-core/cosmos-disk-recovery/files/cosmos-disk-recovery-init-d
+++ b/meta-opencentauri/recipes-core/cosmos-disk-recovery/files/cosmos-disk-recovery-init-d
@@ -1,0 +1,68 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          cosmos-disk-recovery
+# Required-Start:    $local_fs
+# Required-Stop:     $local_fs
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Cosmos offline SWU recovery cache + status log
+### END INIT INFO
+
+COSMOS_DISK_RECOVERY_DIR="${COSMOS_DISK_RECOVERY_DIR:-/data/recovery}"
+
+if [ -r /etc/default/cosmos-disk-recovery ]; then
+    # shellcheck disable=SC1091
+    . /etc/default/cosmos-disk-recovery
+fi
+
+ensure_dir() {
+    if [ -d "${COSMOS_DISK_RECOVERY_DIR}" ]; then
+        return 0
+    fi
+    if mkdir -p "${COSMOS_DISK_RECOVERY_DIR}" 2>/dev/null; then
+        chmod 0755 "${COSMOS_DISK_RECOVERY_DIR}" 2>/dev/null || true
+        return 0
+    fi
+    logger -t cosmos-disk-recovery \
+        "failed to create ${COSMOS_DISK_RECOVERY_DIR}; cached restores unavailable" \
+        2>/dev/null || \
+        echo "cosmos-disk-recovery: failed to create ${COSMOS_DISK_RECOVERY_DIR}" >&2
+    return 1
+}
+
+log_status_lines() {
+    /usr/sbin/cosmos-disk-recovery status 2>/dev/null | while IFS= read -r line; do
+        if ! logger -t cosmos-disk-recovery "${line}" 2>/dev/null; then
+            echo "cosmos-disk-recovery: ${line}" >&2
+        fi
+    done
+}
+
+case "$1" in
+    start|restart|force-reload)
+        ensure_dir
+        rc=$?
+        # Log current recovery-cache state so an operator on UART or
+        # SSH can see what is provisioned without having to invoke the
+        # main script explicitly.
+        log_status_lines
+        exit "${rc}"
+        ;;
+    status)
+        if [ -d "${COSMOS_DISK_RECOVERY_DIR}" ]; then
+            echo "cosmos-disk-recovery: cache dir present at ${COSMOS_DISK_RECOVERY_DIR}"
+            /usr/sbin/cosmos-disk-recovery status
+            exit 0
+        fi
+        echo "cosmos-disk-recovery: cache dir ${COSMOS_DISK_RECOVERY_DIR} absent"
+        exit 3
+        ;;
+    stop)
+        # Stateless boot-time setup; nothing to stop.
+        exit 0
+        ;;
+    *)
+        echo "Usage: $0 {start|stop|restart|force-reload|status}"
+        exit 1
+        ;;
+esac

--- a/meta-opencentauri/recipes-core/cosmos-disk-recovery/files/cosmos-disk-recovery-init-d
+++ b/meta-opencentauri/recipes-core/cosmos-disk-recovery/files/cosmos-disk-recovery-init-d
@@ -52,7 +52,8 @@ case "$1" in
         if [ -d "${COSMOS_DISK_RECOVERY_DIR}" ]; then
             echo "cosmos-disk-recovery: cache dir present at ${COSMOS_DISK_RECOVERY_DIR}"
             /usr/sbin/cosmos-disk-recovery status
-            exit 0
+            rc=$?
+            exit "${rc}"
         fi
         echo "cosmos-disk-recovery: cache dir ${COSMOS_DISK_RECOVERY_DIR} absent"
         exit 3

--- a/meta-opencentauri/recipes-core/hardware-scan/files/hardware-scan
+++ b/meta-opencentauri/recipes-core/hardware-scan/files/hardware-scan
@@ -1,0 +1,72 @@
+#!/bin/sh
+# hardware-scan: emit /run/hardware-scan.env for downstream services.
+
+set -u
+
+ENV_FILE="/run/hardware-scan.env"
+LOG_FILE="/var/log/hardware-scan.log"
+
+mkdir -p /run /var/log 2>/dev/null || true
+
+emit() {
+    printf '%s=%s\n' "$1" "$2"
+}
+
+log() {
+    echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*" >> "$LOG_FILE"
+}
+
+log "hardware-scan start"
+
+WIFI_INTERFACE=""
+for iface in /sys/class/net/wlan*; do
+    [ -e "$iface" ] || continue
+    WIFI_INTERFACE="$(basename "$iface")"
+    break
+done
+
+WIFI_MAC=""
+[ -n "$WIFI_INTERFACE" ] && WIFI_MAC="$(cat /sys/class/net/"$WIFI_INTERFACE"/address 2>/dev/null)"
+
+WIFI_DRIVER=""
+WIFI_CHIP_VID=""
+WIFI_CHIP_PID=""
+if [ -n "$WIFI_INTERFACE" ]; then
+    devpath="$(readlink -f /sys/class/net/"$WIFI_INTERFACE"/device 2>/dev/null)"
+    if [ -n "$devpath" ]; then
+        WIFI_DRIVER="$(basename "$(readlink -f "$devpath"/driver 2>/dev/null)" 2>/dev/null)"
+        usbdev="$devpath"
+        while [ -n "$usbdev" ] && [ "$usbdev" != "/" ]; do
+            if [ -f "$usbdev/idVendor" ] && [ -f "$usbdev/idProduct" ]; then
+                WIFI_CHIP_VID="$(cat "$usbdev/idVendor" 2>/dev/null)"
+                WIFI_CHIP_PID="$(cat "$usbdev/idProduct" 2>/dev/null)"
+                break
+            fi
+            usbdev="$(dirname "$usbdev")"
+        done
+    fi
+fi
+
+WIFI_DRIVERS_LOADED=""
+for mod in $(lsmod 2>/dev/null | awk 'NR>1 {print $1}'); do
+    case "$mod" in
+        rtw*|aic*|brcm*|ath*|iwl*|mt76*|rtl*)
+            WIFI_DRIVERS_LOADED="${WIFI_DRIVERS_LOADED:+$WIFI_DRIVERS_LOADED }$mod"
+            ;;
+    esac
+done
+
+{
+    emit WIFI_INTERFACE "${WIFI_INTERFACE}"
+    emit WIFI_MAC "${WIFI_MAC}"
+    emit WIFI_DRIVER "${WIFI_DRIVER}"
+    emit WIFI_DRIVERS_LOADED "\"${WIFI_DRIVERS_LOADED}\""
+    emit WIFI_CHIP_VID "${WIFI_CHIP_VID}"
+    emit WIFI_CHIP_PID "${WIFI_CHIP_PID}"
+} > "$ENV_FILE"
+
+log "interface=${WIFI_INTERFACE} mac=${WIFI_MAC} driver=${WIFI_DRIVER} vid=${WIFI_CHIP_VID} pid=${WIFI_CHIP_PID}"
+log "drivers_loaded=${WIFI_DRIVERS_LOADED}"
+log "hardware-scan done"
+
+exit 0

--- a/meta-opencentauri/recipes-core/hardware-scan/files/hardware-scan-init-d
+++ b/meta-opencentauri/recipes-core/hardware-scan/files/hardware-scan-init-d
@@ -9,15 +9,29 @@
 ### END INIT INFO
 
 case "$1" in
-    start)
+    start|restart|force-reload)
         /usr/sbin/hardware-scan
+        rc=$?
+        if [ "${rc}" -ne 0 ]; then
+            logger -t hardware-scan "exited with code ${rc}" 2>/dev/null || \
+                echo "hardware-scan: exited with code ${rc}" >&2
+        fi
+        exit "${rc}"
         ;;
-    stop|restart|force-reload|status)
+    status)
+        if [ -r /run/hardware-scan.env ]; then
+            echo "hardware-scan: probe results present at /run/hardware-scan.env"
+            exit 0
+        fi
+        echo "hardware-scan: no probe results (rerun with 'start' to populate)"
+        exit 3
+        ;;
+    stop)
+        # Probe is one-shot at boot; no daemon to stop.
+        exit 0
         ;;
     *)
         echo "Usage: $0 {start|stop|restart|force-reload|status}"
         exit 1
         ;;
 esac
-
-exit 0

--- a/meta-opencentauri/recipes-core/hardware-scan/files/hardware-scan-init-d
+++ b/meta-opencentauri/recipes-core/hardware-scan/files/hardware-scan-init-d
@@ -1,0 +1,23 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          hardware-scan
+# Required-Start:    $local_fs udev
+# Required-Stop:     $local_fs
+# Default-Start:     S
+# Default-Stop:
+# Short-Description: Boot-time hardware probe
+### END INIT INFO
+
+case "$1" in
+    start)
+        /usr/sbin/hardware-scan
+        ;;
+    stop|restart|force-reload|status)
+        ;;
+    *)
+        echo "Usage: $0 {start|stop|restart|force-reload|status}"
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/meta-opencentauri/recipes-core/hardware-scan/hardware-scan_1.0.bb
+++ b/meta-opencentauri/recipes-core/hardware-scan/hardware-scan_1.0.bb
@@ -1,0 +1,37 @@
+SUMMARY = "Boot-time hardware probe"
+DESCRIPTION = "Detects WiFi chip, drivers, and network interface at boot and emits /run/hardware-scan.env for downstream services."
+HOMEPAGE = "https://github.com/Brofalo/pono-print-cosmos"
+LICENSE = "GPL-3.0-only"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-3.0-only;md5=c79ff39f19dfec6d293b95dea7b07891"
+
+SRC_URI = "\
+    file://hardware-scan-init-d \
+    file://hardware-scan \
+"
+
+S = "${WORKDIR}"
+
+RDEPENDS:${PN} = "kmod iproute2 busybox"
+
+inherit update-rc.d
+
+INITSCRIPT_NAME = "hardware-scan"
+# G06 (v4 audit): include stop entry for symmetry. Without it update-rc.d
+# places no K-links in rc0/rc6, so hardware-scan never receives a stop
+# signal at shutdown. The probe's /run/hardware-scan.env is in tmpfs and
+# vanishes on power-off, but any downstream service that reads it during
+# shutdown phase would otherwise see stale state.
+INITSCRIPT_PARAMS = "start 20 S . stop 80 0 6 ."
+
+do_install() {
+    install -d ${D}${sysconfdir}/init.d
+    install -m 0755 ${WORKDIR}/hardware-scan-init-d ${D}${sysconfdir}/init.d/hardware-scan
+
+    install -d ${D}${sbindir}
+    install -m 0755 ${WORKDIR}/hardware-scan ${D}${sbindir}/hardware-scan
+}
+
+FILES:${PN} = "\
+    ${sysconfdir}/init.d/hardware-scan \
+    ${sbindir}/hardware-scan \
+"

--- a/meta-opencentauri/recipes-core/usb-ether-rescue/files/80-usb-net-autoconfig.rules
+++ b/meta-opencentauri/recipes-core/usb-ether-rescue/files/80-usb-net-autoconfig.rules
@@ -1,0 +1,19 @@
+# 80-usb-net-autoconfig.rules
+#
+# Class 217 recovery path: any USB-attached Ethernet interface gets a
+# DHCP bring-up via /usr/sbin/usb-ether-rescue when the kernel registers
+# it. This survives WiFi driver bind failure and MCU bootloader
+# corruption: a pre-plugged USB-to-Ethernet dongle is substrate-
+# independent and the only revert path on the Centauri Carbon that does
+# not require curl-over-WiFi or flashtool-against-MCU.
+#
+# Driver list matches CONFIG_USB_NET_* modules baked into the cosmos
+# kernel (see recipes-kernel/linux/linux-mainline/elegoo-centauri-carbon1/
+# usb-net-adapters.cfg).
+#
+# SUBSYSTEMS=="usb" matches when any parent device is on the USB bus -
+# covers RTL8152/RTL8153, SMSC95XX, AX88179, ASIX, DM9601, SR9700,
+# Pegasus, MCS7830 dongles. The /bin/sh -c wrapper detaches the rescue
+# script so udev does not block on udhcpc lease negotiation (udev kills
+# RUN+= scripts after ~30s).
+ACTION=="add", SUBSYSTEM=="net", SUBSYSTEMS=="usb", RUN+="/bin/sh -c '/usr/sbin/usb-ether-rescue %k </dev/null >/dev/null 2>&1 &'"

--- a/meta-opencentauri/recipes-core/usb-ether-rescue/files/usb-ether-rescue
+++ b/meta-opencentauri/recipes-core/usb-ether-rescue/files/usb-ether-rescue
@@ -132,8 +132,13 @@ log "boot-time scan starting"
 for path in /sys/class/net/*; do
     [ -d "${path}" ] || continue
     name="$(basename "${path}")"
+    # Skip names that can't be USB-Ethernet. We deliberately do NOT skip
+    # "usb*" here: kernel USB CDC drivers commonly assign names like
+    # "usb0", which is exactly the interface we need to bring up.
+    # is_usb_ethernet() does the real check via /sys; the name filter
+    # only weeds out loopback, WiFi, tunnels, virtual bridges, and veth.
     case "${name}" in
-        lo|wlan*|usb*|bnep*|sit*|tun*|tap*|docker*|br-*|veth*) continue ;;
+        lo|wlan*|bnep*|sit*|tun*|tap*|docker*|br-*|veth*) continue ;;
     esac
     bring_up_one "${name}"
 done

--- a/meta-opencentauri/recipes-core/usb-ether-rescue/files/usb-ether-rescue
+++ b/meta-opencentauri/recipes-core/usb-ether-rescue/files/usb-ether-rescue
@@ -1,0 +1,142 @@
+#!/bin/sh
+# usb-ether-rescue - Class 217 recovery path: substrate-independent wired LAN.
+#
+# Modes:
+#   /usr/sbin/usb-ether-rescue          - boot-time scan, brings up every
+#                                          USB-Ethernet iface lacking IPv4.
+#   /usr/sbin/usb-ether-rescue <iface>  - hotplug, brings up the named iface.
+#
+# Invocation surfaces:
+#   - /etc/init.d/usb-ether-rescue at boot (no arg)
+#   - /etc/udev/rules.d/80-usb-net-autoconfig.rules on add events (with iface)
+#
+# Why not just rely on /etc/network/interfaces?
+#   "auto eth0" in interfaces triggers only at boot, only if the iface
+#   is named eth0. USB dongles plugged in after boot, or named enxNNNN
+#   instead of eth0, never get brought up. This script catches both gaps.
+
+set -u
+
+# --- config -----------------------------------------------------------------
+
+USB_ETHER_RESCUE_ENABLED="${USB_ETHER_RESCUE_ENABLED:-1}"
+USB_ETHER_RESCUE_LOG="${USB_ETHER_RESCUE_LOG:-/var/log/usb-ether-rescue.log}"
+USB_ETHER_RESCUE_UDHCPC_T="${USB_ETHER_RESCUE_UDHCPC_T:-3}"
+USB_ETHER_RESCUE_UDHCPC_RETRIES="${USB_ETHER_RESCUE_UDHCPC_RETRIES:-5}"
+USB_ETHER_RESCUE_CARRIER_SETTLE_S="${USB_ETHER_RESCUE_CARRIER_SETTLE_S:-2}"
+
+if [ -r /etc/default/usb-ether-rescue ]; then
+    # shellcheck disable=SC1091
+    . /etc/default/usb-ether-rescue
+fi
+
+[ "${USB_ETHER_RESCUE_ENABLED}" = "1" ] || exit 0
+
+mkdir -p "$(dirname "${USB_ETHER_RESCUE_LOG}")" 2>/dev/null || true
+
+log() {
+    echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*" >>"${USB_ETHER_RESCUE_LOG}" 2>/dev/null
+}
+
+# --- helpers ----------------------------------------------------------------
+
+is_usb_ethernet() {
+    # $1 = interface name. True if sysfs reports it as ethernet (type 1) and
+    # any parent device sits on the usb bus.
+    iface="$1"
+    [ -d "/sys/class/net/${iface}" ] || return 1
+    iftype="$(cat "/sys/class/net/${iface}/type" 2>/dev/null || echo 0)"
+    [ "${iftype}" = "1" ] || return 1
+
+    # Walk up the device tree looking for usb subsystem.
+    dev_link="/sys/class/net/${iface}/device"
+    [ -L "${dev_link}" ] || return 1
+    abs="$(readlink -f "${dev_link}" 2>/dev/null)"
+    case "${abs}" in
+        */usb*) return 0 ;;
+    esac
+    # Fall back: any parent with subsystem=usb.
+    cur="${abs}"
+    while [ -n "${cur}" ] && [ "${cur}" != "/" ]; do
+        sub="${cur}/subsystem"
+        if [ -L "${sub}" ] && [ "$(readlink -f "${sub}")" = "/sys/bus/usb" ]; then
+            return 0
+        fi
+        cur="$(dirname "${cur}")"
+    done
+    return 1
+}
+
+iface_has_ipv4() {
+    ip -4 addr show "$1" 2>/dev/null | grep -q "inet "
+}
+
+iface_named_in_interfaces() {
+    # True if /etc/network/interfaces has an "iface $1" or "auto $1" stanza.
+    # If yes, defer to ifupdown.
+    name="$1"
+    [ -r /etc/network/interfaces ] || return 1
+    grep -qE "^[[:space:]]*(auto|iface)[[:space:]]+${name}([[:space:]]|$)" \
+        /etc/network/interfaces 2>/dev/null
+}
+
+bring_up_one() {
+    iface="$1"
+
+    if ! is_usb_ethernet "${iface}"; then
+        log "skip ${iface}: not a USB ethernet device"
+        return 0
+    fi
+
+    if iface_has_ipv4 "${iface}"; then
+        log "skip ${iface}: already has IPv4"
+        return 0
+    fi
+
+    if iface_named_in_interfaces "${iface}"; then
+        log "ifup ${iface} (declared in /etc/network/interfaces)"
+        ifup "${iface}" >>"${USB_ETHER_RESCUE_LOG}" 2>&1 || \
+            log "ifup ${iface} failed (rc=$?)"
+        return 0
+    fi
+
+    log "direct DHCP bring-up for ${iface}"
+    ip link set "${iface}" up 2>>"${USB_ETHER_RESCUE_LOG}" || {
+        log "ip link set ${iface} up failed"
+        return 1
+    }
+
+    sleep "${USB_ETHER_RESCUE_CARRIER_SETTLE_S}"
+
+    # -b: background after initial dhcp attempt; -F: send hostname;
+    # -t/-T: retries/per-try timeout (bounds total wait so udev does not stall).
+    udhcpc -i "${iface}" \
+        -t "${USB_ETHER_RESCUE_UDHCPC_RETRIES}" \
+        -T "${USB_ETHER_RESCUE_UDHCPC_T}" \
+        -b \
+        -F "$(hostname 2>/dev/null || echo centauri)" \
+        >>"${USB_ETHER_RESCUE_LOG}" 2>&1 \
+        && log "udhcpc launched for ${iface}" \
+        || log "udhcpc launch for ${iface} returned non-zero"
+}
+
+# --- main -------------------------------------------------------------------
+
+if [ "$#" -ge 1 ] && [ -n "$1" ]; then
+    log "hotplug bring-up for $1"
+    bring_up_one "$1"
+    exit 0
+fi
+
+log "boot-time scan starting"
+for path in /sys/class/net/*; do
+    [ -d "${path}" ] || continue
+    name="$(basename "${path}")"
+    case "${name}" in
+        lo|wlan*|usb*|bnep*|sit*|tun*|tap*|docker*|br-*|veth*) continue ;;
+    esac
+    bring_up_one "${name}"
+done
+log "boot-time scan done"
+
+exit 0

--- a/meta-opencentauri/recipes-core/usb-ether-rescue/files/usb-ether-rescue-default
+++ b/meta-opencentauri/recipes-core/usb-ether-rescue/files/usb-ether-rescue-default
@@ -9,8 +9,14 @@ USB_ETHER_RESCUE_ENABLED=1
 # Where the rescue script logs its actions.
 USB_ETHER_RESCUE_LOG=/var/log/usb-ether-rescue.log
 
-# DHCP-attempt timeout (-T) and retries (-t) for udhcpc. Combined upper
-# bound is ~30s wall time; udhcpc backgrounds after that if no lease.
+# DHCP-attempt timing for udhcpc.
+#   USB_ETHER_RESCUE_UDHCPC_T:       per-try timeout (-T), seconds
+#   USB_ETHER_RESCUE_UDHCPC_RETRIES: retry count (-t)
+# Bare DHCP wall time is T * RETRIES = 3 * 5 = 15s. Real wall time runs
+# closer to ~30s once you fold in udev settle, CARRIER_SETTLE_S below,
+# and udhcpc internal backoff between retries. After RETRIES exhaust
+# udhcpc backgrounds and stops blocking boot. Tune both knobs when
+# adjusting the boot-time DHCP budget.
 USB_ETHER_RESCUE_UDHCPC_T=3
 USB_ETHER_RESCUE_UDHCPC_RETRIES=5
 

--- a/meta-opencentauri/recipes-core/usb-ether-rescue/files/usb-ether-rescue-default
+++ b/meta-opencentauri/recipes-core/usb-ether-rescue/files/usb-ether-rescue-default
@@ -1,0 +1,19 @@
+# /etc/default/usb-ether-rescue -- runtime config for usb-ether-rescue.
+#
+# Override defaults here; the rescue script sources this file if present.
+
+# Master switch. Set to 0 to disable both the boot-time scan and the
+# udev hotplug path without removing the package.
+USB_ETHER_RESCUE_ENABLED=1
+
+# Where the rescue script logs its actions.
+USB_ETHER_RESCUE_LOG=/var/log/usb-ether-rescue.log
+
+# DHCP-attempt timeout (-T) and retries (-t) for udhcpc. Combined upper
+# bound is ~30s wall time; udhcpc backgrounds after that if no lease.
+USB_ETHER_RESCUE_UDHCPC_T=3
+USB_ETHER_RESCUE_UDHCPC_RETRIES=5
+
+# Carrier-settle delay after link-up before launching udhcpc. Some USB
+# dongles take ~1-2s to assert carrier after enumeration.
+USB_ETHER_RESCUE_CARRIER_SETTLE_S=2

--- a/meta-opencentauri/recipes-core/usb-ether-rescue/files/usb-ether-rescue-init-d
+++ b/meta-opencentauri/recipes-core/usb-ether-rescue/files/usb-ether-rescue-init-d
@@ -1,0 +1,23 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          usb-ether-rescue
+# Required-Start:    $local_fs $remote_fs $network
+# Required-Stop:     $local_fs $remote_fs
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Boot-time USB-Ethernet DHCP bring-up (Class 217 recovery)
+### END INIT INFO
+
+case "$1" in
+    start)
+        /usr/sbin/usb-ether-rescue
+        ;;
+    stop|restart|force-reload|status)
+        ;;
+    *)
+        echo "Usage: $0 {start|stop|restart|force-reload|status}"
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/meta-opencentauri/recipes-core/usb-ether-rescue/files/usb-ether-rescue-init-d
+++ b/meta-opencentauri/recipes-core/usb-ether-rescue/files/usb-ether-rescue-init-d
@@ -13,14 +13,16 @@ case "$1" in
         /usr/sbin/usb-ether-rescue
         rc=$?
         if [ "${rc}" -ne 0 ]; then
-            logger -t usb-ether-rescue "boot-time scan exited with code ${rc}" \
+            logger -t usb-ether-rescue "scan exited with code ${rc}" \
                 2>/dev/null || \
-                echo "usb-ether-rescue: boot-time scan exited with code ${rc}" >&2
+                echo "usb-ether-rescue: scan exited with code ${rc}" >&2
         fi
-        # Boot must not block on rescue-script failure; mask non-zero rc
-        # so init does not flag the boot stage broken. The logger line
-        # above keeps the diagnostic visible in syslog.
-        exit 0
+        # Propagate the rescue-script exit code so LSB-aware callers
+        # (service foo start, monitoring tools, operators) can detect
+        # probe failures. Busybox sysv-init at boot tolerates non-zero
+        # rc from a start script (logs + continues to the next script),
+        # so this does not block boot. Symmetric with hardware-scan.
+        exit "${rc}"
         ;;
     status)
         if [ -r /var/log/usb-ether-rescue.log ]; then

--- a/meta-opencentauri/recipes-core/usb-ether-rescue/files/usb-ether-rescue-init-d
+++ b/meta-opencentauri/recipes-core/usb-ether-rescue/files/usb-ether-rescue-init-d
@@ -9,15 +9,33 @@
 ### END INIT INFO
 
 case "$1" in
-    start)
+    start|restart|force-reload)
         /usr/sbin/usb-ether-rescue
+        rc=$?
+        if [ "${rc}" -ne 0 ]; then
+            logger -t usb-ether-rescue "boot-time scan exited with code ${rc}" \
+                2>/dev/null || \
+                echo "usb-ether-rescue: boot-time scan exited with code ${rc}" >&2
+        fi
+        # Boot must not block on rescue-script failure; mask non-zero rc
+        # so init does not flag the boot stage broken. The logger line
+        # above keeps the diagnostic visible in syslog.
+        exit 0
         ;;
-    stop|restart|force-reload|status)
+    status)
+        if [ -r /var/log/usb-ether-rescue.log ]; then
+            echo "usb-ether-rescue: log present at /var/log/usb-ether-rescue.log"
+            exit 0
+        fi
+        echo "usb-ether-rescue: no log present (rerun with 'start' to scan)"
+        exit 3
+        ;;
+    stop)
+        # Boot-time scan + udev hotplug are stateless one-shots; nothing to stop.
+        exit 0
         ;;
     *)
         echo "Usage: $0 {start|stop|restart|force-reload|status}"
         exit 1
         ;;
 esac
-
-exit 0

--- a/meta-opencentauri/recipes-core/usb-ether-rescue/usb-ether-rescue_1.0.bb
+++ b/meta-opencentauri/recipes-core/usb-ether-rescue/usb-ether-rescue_1.0.bb
@@ -1,0 +1,58 @@
+# Class 217 recovery path: substrate-independent wired LAN bring-up.
+#
+# When AIC8800 WiFi fails to bind (cosmos brick of 2026-05-17) or when a
+# Centauri Carbon ends up on a network with a broken AP, plugging in any
+# of the USB-Ethernet adapters the kernel already supports (RTL8152,
+# RTL8153, SMSC95XX, AX88179, ASIX, DM9601, SR9700, Pegasus, MCS7830 -
+# see recipes-kernel/linux/linux-mainline/elegoo-centauri-carbon1/
+# usb-net-adapters.cfg) MUST give a no-touch wired LAN. The dongle path
+# is the only revert path on this hardware that does not depend on the
+# state of WiFi or the bed MCU bootloader.
+#
+# Companion to wifi-rescue: wifi-rescue handles the AIC8800 unbind/rebind
+# bandage; usb-ether-rescue handles "WiFi is dead, plug the cable in".
+SUMMARY = "Auto-bring-up USB Ethernet adapters for failsafe LAN recovery"
+DESCRIPTION = "Hot-plug aware DHCP bring-up for USB-Ethernet adapters \
+plugged into a Centauri Carbon when WiFi is dead or absent."
+HOMEPAGE = "https://github.com/Brofalo/pono-print-cosmos"
+LICENSE = "GPL-3.0-only"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-3.0-only;md5=c79ff39f19dfec6d293b95dea7b07891"
+
+SRC_URI = "\
+    file://usb-ether-rescue-init-d \
+    file://usb-ether-rescue \
+    file://usb-ether-rescue-default \
+    file://80-usb-net-autoconfig.rules \
+"
+
+S = "${WORKDIR}"
+
+RDEPENDS:${PN} = "kmod iproute2 init-ifupdown busybox-udhcpc"
+
+inherit update-rc.d
+
+INITSCRIPT_NAME = "usb-ether-rescue"
+# After wifi-rescue (80), before user services. Network must already be
+# available (ifupdown completed). Stop early on shutdown.
+INITSCRIPT_PARAMS = "defaults 85 15"
+
+do_install() {
+    install -d ${D}${sysconfdir}/init.d
+    install -m 0755 ${WORKDIR}/usb-ether-rescue-init-d ${D}${sysconfdir}/init.d/usb-ether-rescue
+
+    install -d ${D}${sbindir}
+    install -m 0755 ${WORKDIR}/usb-ether-rescue ${D}${sbindir}/usb-ether-rescue
+
+    install -d ${D}${sysconfdir}/default
+    install -m 0644 ${WORKDIR}/usb-ether-rescue-default ${D}${sysconfdir}/default/usb-ether-rescue
+
+    install -d ${D}${sysconfdir}/udev/rules.d
+    install -m 0644 ${WORKDIR}/80-usb-net-autoconfig.rules ${D}${sysconfdir}/udev/rules.d/80-usb-net-autoconfig.rules
+}
+
+FILES:${PN} = "\
+    ${sysconfdir}/init.d/usb-ether-rescue \
+    ${sysconfdir}/default/usb-ether-rescue \
+    ${sysconfdir}/udev/rules.d/80-usb-net-autoconfig.rules \
+    ${sbindir}/usb-ether-rescue \
+"

--- a/meta-opencentauri/recipes-core/wifi-rescue/files/wifi-rescue
+++ b/meta-opencentauri/recipes-core/wifi-rescue/files/wifi-rescue
@@ -162,9 +162,15 @@ if iface_present; then
     if iface_has_carrier; then
         log "${iface} present with carrier, no IPv4; running ifup"
         ifup "${iface}" 2>&1 || log "ifup ${iface} returned non-zero"
-        exit 0
+        sleep "${WIFI_RESCUE_POST_RELOAD_S}"
+        if iface_has_ipv4; then
+            log "${iface} has IPv4 after ifup; done"
+            exit 0
+        fi
+        log "${iface} no IPv4 after ifup; escalating to wpa_cli soft-rescue"
+    else
+        log "${iface} present without carrier; trying wpa_cli soft-rescue"
     fi
-    log "${iface} present without carrier; trying wpa_cli soft-rescue"
     if wpa_cli_soft_rescue; then
         sleep "${WIFI_RESCUE_POST_RELOAD_S}"
         if iface_has_carrier && iface_has_ipv4; then
@@ -204,11 +210,15 @@ sleep "${WIFI_RESCUE_POST_RELOAD_S}"
 if iface_present; then
     log "${iface} present after driver reload; running ifup"
     ifup "${iface}" 2>&1 || log "ifup ${iface} returned non-zero"
-    log "wifi-rescue done"
-    exit 0
+    sleep "${WIFI_RESCUE_POST_RELOAD_S}"
+    if iface_has_ipv4; then
+        log "${iface} has IPv4 after driver reload; done"
+        exit 0
+    fi
+    log "${iface} no IPv4 after driver reload; escalating to USB unbind/rebind"
 fi
 
-log "${iface} absent after driver reload; trying USB unbind/rebind"
+log "${iface} absent or unassociated after driver reload; trying USB unbind/rebind"
 for vid in ${WIFI_RESCUE_USB_VENDORS}; do
     for dev in /sys/bus/usb/devices/*; do
         [ -e "${dev}/idVendor" ] || continue
@@ -231,11 +241,15 @@ sleep "${WIFI_RESCUE_POST_RELOAD_S}"
 if iface_present; then
     log "${iface} present after USB unbind/rebind; running ifup"
     ifup "${iface}" 2>&1 || log "ifup ${iface} returned non-zero"
-    log "wifi-rescue done"
-    exit 0
+    sleep "${WIFI_RESCUE_POST_RELOAD_S}"
+    if iface_has_ipv4; then
+        log "${iface} has IPv4 after USB unbind/rebind; done"
+        exit 0
+    fi
+    log "${iface} no IPv4 after USB unbind/rebind; escalating to PCIe rescan"
 fi
 
-log "${iface} absent after USB rebind; trying PCIe rescan"
+log "${iface} absent or unassociated after USB rebind; trying PCIe rescan"
 if [ -w /sys/bus/pci/rescan ]; then
     echo 1 > /sys/bus/pci/rescan 2>&1 || log "  PCIe rescan failed"
 else
@@ -247,11 +261,15 @@ sleep "${WIFI_RESCUE_POST_RELOAD_S}"
 if iface_present; then
     log "${iface} present after PCIe rescan; running ifup"
     ifup "${iface}" 2>&1 || log "ifup ${iface} returned non-zero"
-    log "wifi-rescue done"
-    exit 0
+    sleep "${WIFI_RESCUE_POST_RELOAD_S}"
+    if iface_has_ipv4; then
+        log "${iface} has IPv4 after PCIe rescan; done"
+        exit 0
+    fi
+    log "${iface} no IPv4 after PCIe rescan; all recovery stages exhausted"
 fi
 
-log "${iface} still absent after all recovery steps; giving up this boot"
+log "${iface} still absent or unassociated after all recovery steps; giving up this boot"
 log "lsmod (WiFi-relevant):"
 lsmod | grep -iE 'aic|rtw|cfg80211|mac80211' 2>&1 || true
 log "USB devices:"

--- a/meta-opencentauri/recipes-core/wifi-rescue/files/wifi-rescue
+++ b/meta-opencentauri/recipes-core/wifi-rescue/files/wifi-rescue
@@ -1,0 +1,262 @@
+#!/bin/sh
+# wifi-rescue: boot-time wlan0 recovery for OpenCentauri/cosmos#184.
+#
+# Recovers wlan0 across four failure classes:
+#   - no IPv4 with carrier: rerun ifup (DHCP path).
+#   - no carrier (association failed): restart wpa_supplicant then ifup.
+#   - interface absent: reload driver modules, USB unbind/rebind, PCIe rescan.
+# Each step skipped once wlan0 returns. Overridable via /etc/default/wifi-rescue.
+
+set -u
+
+WIFI_RESCUE_ENABLED="${WIFI_RESCUE_ENABLED:-1}"
+WIFI_RESCUE_SETTLE_S="${WIFI_RESCUE_SETTLE_S:-5}"
+WIFI_RESCUE_POST_RELOAD_S="${WIFI_RESCUE_POST_RELOAD_S:-3}"
+WIFI_RESCUE_INTERFACE="${WIFI_RESCUE_INTERFACE:-wlan0}"
+WIFI_RESCUE_LOG="${WIFI_RESCUE_LOG:-/var/log/wifi-rescue.log}"
+WIFI_RESCUE_DRIVERS="${WIFI_RESCUE_DRIVERS:-aic8800_fdrv rtw_8821ce rtw_8821cu rtw_8821cs rtw_8821c rtw_core}"
+# USB VIDs eligible for unbind/rebind. Defaults cover:
+#   a69c = AIC Semiconductor (aic8800 family)
+#   0bda = Realtek (RTL8821CU and friends; e.g. RTL8821CU 0bda:c811 found on
+#          2026-05-17 brick recovery despite aic8800_fdrv also loading)
+# Add more space-separated VIDs as new Centauri Carbon SKUs ship different radios.
+WIFI_RESCUE_USB_VENDORS="${WIFI_RESCUE_USB_VENDORS-a69c 0bda}"
+
+if [ -r /run/hardware-scan.env ]; then
+    . /run/hardware-scan.env
+    [ -n "${WIFI_INTERFACE:-}" ] && WIFI_RESCUE_INTERFACE="${WIFI_INTERFACE}"
+    [ -n "${WIFI_DRIVERS_LOADED:-}" ] && WIFI_RESCUE_DRIVERS="${WIFI_DRIVERS_LOADED}"
+    if [ -n "${WIFI_CHIP_VID:-}" ]; then
+        case " ${WIFI_RESCUE_USB_VENDORS} " in
+            *" ${WIFI_CHIP_VID} "*) ;;
+            *) WIFI_RESCUE_USB_VENDORS="${WIFI_RESCUE_USB_VENDORS} ${WIFI_CHIP_VID}" ;;
+        esac
+    fi
+fi
+
+if [ -r /etc/default/wifi-rescue ]; then
+    . /etc/default/wifi-rescue
+fi
+
+[ "${WIFI_RESCUE_ENABLED}" = "1" ] || exit 0
+[ -n "${WIFI_RESCUE_INTERFACE}" ] || exit 0
+
+iface="${WIFI_RESCUE_INTERFACE}"
+log_path="${WIFI_RESCUE_LOG}"
+
+mkdir -p "$(dirname "${log_path}")" 2>/dev/null || true
+: > "${log_path}" 2>/dev/null || true
+exec >>"${log_path}" 2>&1
+
+log() {
+    echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"
+}
+
+iface_present() {
+    ip link show "${iface}" >/dev/null 2>&1
+}
+
+iface_has_ipv4() {
+    ip -4 addr show "${iface}" 2>/dev/null | grep -q 'inet '
+}
+
+iface_has_carrier() {
+    [ "$(cat /sys/class/net/${iface}/carrier 2>/dev/null)" = "1" ]
+}
+
+wpa_cli_soft_rescue() {
+    command -v wpa_cli >/dev/null 2>&1 || return 1
+    pidof wpa_supplicant >/dev/null 2>&1 || return 1
+    log "wpa_cli reconfigure + reassociate on ${iface}"
+    wpa_cli -i "${iface}" reconfigure >/dev/null 2>&1 || return 1
+    sleep 1
+    wpa_cli -i "${iface}" reassociate >/dev/null 2>&1 || return 1
+    return 0
+}
+
+restart_wpa() {
+    log "tearing down ${iface} and wpa_supplicant"
+    ifdown "${iface}" >/dev/null 2>&1 || true
+    pkill -x wpa_supplicant >/dev/null 2>&1 || true
+    sleep 1
+}
+
+# Probe whether a group exists. 0 = yes, 1 = no, 2 = can't tell (no
+# getent + no /etc/group). rc=2 must NOT be treated as "no" by the
+# caller; a stripped image that lacks both probes shouldn't have its
+# wpa_supplicant.conf rewritten on a guess.
+_group_exists() {
+    grp="$1"
+    [ -n "${grp}" ] || return 2
+    if command -v getent >/dev/null 2>&1; then
+        if getent group "${grp}" >/dev/null 2>&1; then
+            return 0
+        fi
+        # getent ran, group not in any nsswitch source.
+        return 1
+    fi
+    if [ -r /etc/group ]; then
+        if awk -F: -v g="${grp}" '$1==g {found=1} END {exit !found}' /etc/group; then
+            return 0
+        fi
+        return 1
+    fi
+    return 2
+}
+
+# Self-heal a wpa_supplicant.conf that references a GROUP= the image
+# doesn't have. Cosmos 0.0.6 (busybox Yocto) doesn't ship the netdev
+# group; an operator config carrying
+#   ctrl_interface=DIR=... GROUP=netdev
+# makes wpa_supplicant exit with
+#   CTRL: Invalid group 'netdev'
+#   Failed to initialize control interface
+# before any association attempt. modprobe cycling can't fix it -- the
+# supplicant never starts. Strip the GROUP= clause (with backup) only
+# when we're sure the group is absent. Returns 0 if no change, 1 if
+# the conf was edited. See docs/post-mortems/2026-05-17-wifi-brick.md.
+validate_wpa_group() {
+    conf="${WPA_CONF:-/etc/wpa_supplicant.conf}"
+    [ -r "${conf}" ] || return 0
+    grp="$(sed -n 's/^[[:space:]]*ctrl_interface=.*GROUP=\([^[:space:]]*\).*/\1/p' "${conf}" | head -n1)"
+    [ -n "${grp}" ] || return 0
+    _group_exists "${grp}"
+    case "$?" in
+        0)
+            return 0
+            ;;
+        2)
+            # Can't verify; don't rewrite the conf. Log it so the next
+            # operator sees what happened if the supplicant still fails.
+            log "wpa_supplicant.conf references GROUP='${grp}'; can't verify (no getent, no /etc/group). Leaving conf untouched."
+            return 0
+            ;;
+    esac
+    # Group is absent. Strip the GROUP= clause and back up the original.
+    backup="${conf}.broken-group-${grp}-stripped"
+    log "wpa_supplicant.conf references missing group '${grp}'; stripping (backup: ${backup})"
+    cp -a "${conf}" "${backup}" 2>/dev/null || log "  backup copy failed (continuing)"
+    sed -i -E "s/^([[:space:]]*ctrl_interface=[^[:space:]]*)[[:space:]]+GROUP=${grp}[^[:space:]]*$/\1/" "${conf}"
+    return 1
+}
+
+log "wifi-rescue start (iface=${iface})"
+
+# Class 218 instance #2 substrate fix: catch wpa_supplicant config bugs
+# the modprobe cycle cannot recover from. Run before any rescue step so
+# subsequent ifup / wpa_cli sees a healed config.
+if ! validate_wpa_group; then
+    log "wpa_supplicant.conf was healed; restarting wpa_supplicant"
+    pkill -x wpa_supplicant >/dev/null 2>&1 || true
+    sleep 1
+fi
+
+sleep "${WIFI_RESCUE_SETTLE_S}"
+
+if iface_present && iface_has_ipv4; then
+    log "${iface} present with IPv4; no action"
+    exit 0
+fi
+
+if iface_present; then
+    if iface_has_carrier; then
+        log "${iface} present with carrier, no IPv4; running ifup"
+        ifup "${iface}" 2>&1 || log "ifup ${iface} returned non-zero"
+        exit 0
+    fi
+    log "${iface} present without carrier; trying wpa_cli soft-rescue"
+    if wpa_cli_soft_rescue; then
+        sleep "${WIFI_RESCUE_POST_RELOAD_S}"
+        if iface_has_carrier && iface_has_ipv4; then
+            log "${iface} associated with IPv4 after wpa_cli soft-rescue; done"
+            exit 0
+        fi
+        log "${iface} no IPv4 after soft-rescue; escalating to wpa_supplicant restart"
+    fi
+
+    restart_wpa
+    ifup "${iface}" 2>&1 || log "ifup ${iface} returned non-zero"
+    sleep "${WIFI_RESCUE_POST_RELOAD_S}"
+    if iface_has_carrier && iface_has_ipv4; then
+        log "${iface} associated with IPv4 after wpa restart; done"
+        exit 0
+    fi
+    log "${iface} did not associate after wpa restart; escalating to driver reload"
+fi
+
+log "${iface} absent or unassociated; reloading drivers"
+for drv in ${WIFI_RESCUE_DRIVERS}; do
+    if lsmod | awk '{print $1}' | grep -qx "${drv}"; then
+        log "modprobe -r ${drv}"
+        modprobe -r "${drv}" 2>&1 || log "  modprobe -r ${drv} failed (continuing)"
+    fi
+done
+
+sleep 1
+
+for drv in ${WIFI_RESCUE_DRIVERS}; do
+    log "modprobe ${drv}"
+    modprobe "${drv}" 2>&1 || log "  modprobe ${drv} failed (driver/chip absent)"
+done
+
+sleep "${WIFI_RESCUE_POST_RELOAD_S}"
+
+if iface_present; then
+    log "${iface} present after driver reload; running ifup"
+    ifup "${iface}" 2>&1 || log "ifup ${iface} returned non-zero"
+    log "wifi-rescue done"
+    exit 0
+fi
+
+log "${iface} absent after driver reload; trying USB unbind/rebind"
+for vid in ${WIFI_RESCUE_USB_VENDORS}; do
+    for dev in /sys/bus/usb/devices/*; do
+        [ -e "${dev}/idVendor" ] || continue
+        dev_vid="$(cat "${dev}/idVendor" 2>/dev/null)"
+        if [ "${dev_vid}" = "${vid}" ]; then
+            devname="$(basename "${dev}")"
+            log "  USB ${vid}: unbinding ${devname}"
+            echo "${devname}" > /sys/bus/usb/drivers/usb/unbind 2>&1 \
+                || log "    unbind failed for ${devname}"
+            sleep 1
+            log "  USB ${vid}: rebinding ${devname}"
+            echo "${devname}" > /sys/bus/usb/drivers/usb/bind 2>&1 \
+                || log "    rebind failed for ${devname}"
+        fi
+    done
+done
+
+sleep "${WIFI_RESCUE_POST_RELOAD_S}"
+
+if iface_present; then
+    log "${iface} present after USB unbind/rebind; running ifup"
+    ifup "${iface}" 2>&1 || log "ifup ${iface} returned non-zero"
+    log "wifi-rescue done"
+    exit 0
+fi
+
+log "${iface} absent after USB rebind; trying PCIe rescan"
+if [ -w /sys/bus/pci/rescan ]; then
+    echo 1 > /sys/bus/pci/rescan 2>&1 || log "  PCIe rescan failed"
+else
+    log "  /sys/bus/pci/rescan not writable; skipping"
+fi
+
+sleep "${WIFI_RESCUE_POST_RELOAD_S}"
+
+if iface_present; then
+    log "${iface} present after PCIe rescan; running ifup"
+    ifup "${iface}" 2>&1 || log "ifup ${iface} returned non-zero"
+    log "wifi-rescue done"
+    exit 0
+fi
+
+log "${iface} still absent after all recovery steps; giving up this boot"
+log "lsmod (WiFi-relevant):"
+lsmod | grep -iE 'aic|rtw|cfg80211|mac80211' 2>&1 || true
+log "USB devices:"
+ls /sys/bus/usb/devices/ 2>&1 | head -20
+log "PCI WiFi-class devices:"
+lspci 2>/dev/null | grep -iE 'wireless|wifi|802\.11' 2>&1 || log "  (no lspci output or no WiFi PCI device)"
+log "wifi-rescue failed"
+exit 1

--- a/meta-opencentauri/recipes-core/wifi-rescue/files/wifi-rescue-default
+++ b/meta-opencentauri/recipes-core/wifi-rescue/files/wifi-rescue-default
@@ -1,0 +1,9 @@
+# /etc/default/wifi-rescue. Changes take effect at next boot.
+
+WIFI_RESCUE_ENABLED=1
+WIFI_RESCUE_SETTLE_S=5
+WIFI_RESCUE_POST_RELOAD_S=3
+WIFI_RESCUE_INTERFACE="wlan0"
+WIFI_RESCUE_LOG="/var/log/wifi-rescue.log"
+WIFI_RESCUE_DRIVERS="aic8800_fdrv rtw_8821ce rtw_8821cu rtw_8821cs rtw_8821c rtw_core"
+WIFI_RESCUE_USB_VENDORS="a69c 0bda"

--- a/meta-opencentauri/recipes-core/wifi-rescue/files/wifi-rescue-init-d
+++ b/meta-opencentauri/recipes-core/wifi-rescue/files/wifi-rescue-init-d
@@ -1,0 +1,23 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          wifi-rescue
+# Required-Start:    $local_fs $remote_fs $network
+# Required-Stop:     $local_fs $remote_fs
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Boot-time wlan0 driver-bind retry (workaround for #184)
+### END INIT INFO
+
+case "$1" in
+    start)
+        /usr/sbin/wifi-rescue
+        ;;
+    stop|restart|force-reload|status)
+        ;;
+    *)
+        echo "Usage: $0 {start|stop|restart|force-reload|status}"
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/meta-opencentauri/recipes-core/wifi-rescue/wifi-rescue_1.0.bb
+++ b/meta-opencentauri/recipes-core/wifi-rescue/wifi-rescue_1.0.bb
@@ -1,0 +1,38 @@
+# Workaround for OpenCentauri/cosmos#184 (wlan0 missing or unassociated at boot).
+SUMMARY = "Boot-time wlan0 recovery helper"
+DESCRIPTION = "Recovers wlan0 across driver-bind, association, and DHCP failure modes after boot."
+HOMEPAGE = "https://github.com/Brofalo/pono-print-cosmos"
+LICENSE = "GPL-3.0-only"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-3.0-only;md5=c79ff39f19dfec6d293b95dea7b07891"
+
+SRC_URI = "\
+    file://wifi-rescue-init-d \
+    file://wifi-rescue \
+    file://wifi-rescue-default \
+"
+
+S = "${WORKDIR}"
+
+RDEPENDS:${PN} = "kmod iproute2 init-ifupdown wpa-supplicant"
+
+inherit update-rc.d
+
+INITSCRIPT_NAME = "wifi-rescue"
+INITSCRIPT_PARAMS = "defaults 80 20"
+
+do_install() {
+    install -d ${D}${sysconfdir}/init.d
+    install -m 0755 ${WORKDIR}/wifi-rescue-init-d ${D}${sysconfdir}/init.d/wifi-rescue
+
+    install -d ${D}${sbindir}
+    install -m 0755 ${WORKDIR}/wifi-rescue ${D}${sbindir}/wifi-rescue
+
+    install -d ${D}${sysconfdir}/default
+    install -m 0644 ${WORKDIR}/wifi-rescue-default ${D}${sysconfdir}/default/wifi-rescue
+}
+
+FILES:${PN} = "\
+    ${sysconfdir}/init.d/wifi-rescue \
+    ${sysconfdir}/default/wifi-rescue \
+    ${sbindir}/wifi-rescue \
+"


### PR DESCRIPTION
## Summary

Closes #184 by adding a self-healing WiFi rescue chain and a USB-Ethernet plug-and-go fallback. The reporter's symptoms map directly to two compounded substrate defects on Centauri Carbon units shipping the Realtek RTL8821CU radio (USB VID:PID `0bda:c811`). Both are recovered automatically by this change.

## Why

Issue #184 reads: WiFi disappeared on cosmos 0.0.6, only a loading ring in the WiFi settings, factory reset didn't help, can't go back to OC-patched without network. Forensic walk on a Brofalo fork brick (2026-05-17) anchored the two root causes:

1. **`wpa_supplicant.conf` references a missing group.** `/etc/wpa_supplicant.conf` ships with `ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev` on cosmos. The image's busybox-based rootfs has no `netdev` group; `wpa_supplicant` exits with `CTRL: Invalid group 'netdev'` / `Failed to initialize control interface` before any association attempt. From the operator's UI: scan never produces results, only a loading spinner.
2. **RTL8821CU USB endpoint wedges over long uptime.** When the chip's USB endpoint stops responding (a class of failure documented across Realtek 882xCU USB radios), recovery requires walking `/sys/bus/usb/devices` and unbinding+rebinding by VID. The baseline image has no such logic; once the chip wedges, the user's only option is reflash, but reflash needs network. Class 217 substrate-recovery deadlock.

Layered with one more failure that doesn't apply to #184 but is in the same recovery surface: rtw_8821cu's 4-way EAPOL against ASUSwrt AiMesh WPA2+SAE transition-mode APs silently times out. Userland workaround is plugging a USB-Ethernet dongle, which the operator currently has no `cosmos`-side support for. This PR adds that path too.

## What ships

Four new recipes under `meta-opencentauri/recipes-core/`:

### `wifi-rescue/`

Boot-time + on-failure rescue chain (init.d, priority `defaults 80 20`):

- `validate_wpa_group()`: detects `GROUP=<name>` in `wpa_supplicant.conf`, runs `getent group <name>`; if absent, writes a backup at `<conf>.broken-group-<name>-stripped` and strips the clause in-place. No-op when the group exists or no `GROUP=` clause is present.
- modprobe a known set of cosmos radio drivers: `aic8800_fdrv rtw_8821ce rtw_8821cu rtw_8821cs rtw_8821c rtw_core`.
- `ifdown wlan0; ifup wlan0; wpa_cli reconfigure` cycle.
- USB unbind/rebind walk over configured VIDs (default `a69c 0bda`; override via `/etc/default/wifi-rescue`).
- Final state to `/var/log/wifi-rescue.log` with timestamps.

Idempotent. Degrades gracefully if any binary is absent (logs a note, continues to the next step). Returns clean exit if `wlan0` is already associated.

### `hardware-scan/`

Boot-time hardware inventory recipe. Writes `/run/hardware-scan.env` with USB VID/PID enumeration of wireless+ethernet adapters. `wifi-rescue` reads this so per-unit chip discovery overrides the static default. No-op on units with no detected wireless adapter.

### `usb-ether-rescue/`

Hot-plug USB Ethernet recovery (udev + init.d):

- udev rule `80-usb-net-autoconfig.rules` catches `add` events for common USB-Ethernet VIDs (RTL8152, AX88179, ASIX-family).
- init.d script brings the interface up via DHCP within ~5 seconds of plug.
- Stranded operator plugs any cheap USB-Ethernet adapter, the network comes up, and `update-cosmos` / `opkg` / `scp` paths all work again.

### `cosmos-disk-recovery/`

Operator-invoked offline SWU flash from local disk or USB thumb drive. The companion to `update-scripts/switch-to-stock` and `update-scripts/switch-to-oc-patched`: same flash primitives (`restore-mcu-firmware`, `flash`, `fw_setenv bootcmd`), no network required.

Subcommands:

- `cosmos-disk-recovery scan-usb`: list SWU candidates on currently-mounted USB drives at `/tmp/usb/*` (matches `oc-restore.swu`, `stock-restore.swu`, `cosmos-recovery.swu`, `recovery.swu`).
- `cosmos-disk-recovery restore-oc [<path>]`: flash an OC-patched SWU. Defaults to `/data/recovery/oc-restore.swu`; falls back to scanning USB drives for the same basename when the cache is empty. Does not touch the bed MCU bootloader unless the SWU embeds `dsp0_partition` (the stock-bootloader signature).
- `cosmos-disk-recovery restore-stock [<path>]`: flash a stock OC SWU. Defaults to `/data/recovery/stock-restore.swu`. Always calls `restore-mcu-firmware` first; resets u-boot bootcmd to the stock sequence after flash so the printer comes back up on stock.
- `cosmos-disk-recovery validate <path>`: sanity-check (file present, size above 1 MiB floor) without flashing.
- `cosmos-disk-recovery status`: report presence + validity of the two cached SWUs.

Does not touch `usb-mount`'s existing `emergency.swu` auto-flash path. Reads only from already-mounted partitions to avoid racing `usb-automount`. Logs to `/var/log/cosmos-disk-recovery.log`. Uses `uiprompt` / `uiclear` when available for touchscreen visibility; degrades gracefully when grumpyscreen is down (UART / SSH still work).

Closes the operator-recovery gap: if WiFi is dead and no USB-Ethernet dongle is available, the operator drops a known-good SWU on a USB stick (or onto `/data/recovery/` via any prior path), then runs one command on UART or SSH to restore.

### Image-base wiring

`opencentauri-image-base.bb` gains four lines in `CORE_IMAGE_EXTRA_INSTALL`:

```
+    hardware-scan \
+    wifi-rescue \
+    usb-ether-rescue \
+    cosmos-disk-recovery \
```

Opt-out via standard `IMAGE_INSTALL_remove` if a deployment wants the lighter image.

### Documentation

`docs/post-mortems/2026-05-17-wifi-brick.md`: the forensic walk that anchored the two root causes. Includes the misdiagnosis chain (initially attributed to `aic8800` driver bind failure based on `lsmod`; corrected via `lsusb` from UART root shell) so future operators don't repeat the same hypothesis-anchoring mistake.

## Test plan

Reviewers can verify:

1. **Build succeeds:** `bitbake opencentauri-upgrade` produces a SWU with the three new recipes installed. Image manifest contains `wifi-rescue`, `hardware-scan`, `usb-ether-rescue`.
2. **Init scripts present:** built image has `/etc/init.d/wifi-rescue`, `/etc/init.d/hardware-scan`, `/etc/init.d/usb-ether-rescue` with executable bits.
3. **WPA-group self-heal:** on a unit with an artificially-broken config:
   ```
   sed -i 's|ctrl_interface=DIR=/var/run/wpa_supplicant|ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=nonexistent|' /etc/wpa_supplicant.conf
   /etc/init.d/wifi-rescue start
   cat /var/log/wifi-rescue.log
   ```
   Expected log line: `wpa_supplicant.conf references missing group 'nonexistent'; stripping (backup: /etc/wpa_supplicant.conf.broken-group-nonexistent-stripped)`. Backup file present. `grep -c 'GROUP=' /etc/wpa_supplicant.conf` returns `0`.
4. **USB-Ethernet hot-plug:** with a USB Ethernet dongle (RTL8152 or AX88179) plugged in post-boot, `ip link` shows the interface up + `ip addr` shows a DHCP-assigned address within ~5 seconds.
5. **No regression on healthy units:** clean cosmos 0.0.6 booting with valid `wpa_supplicant.conf` + working WiFi shows wifi-rescue exiting cleanly (no spurious USB rebinds, no log noise beyond the `start` line).
6. **Disk-recovery wiring present:** built image has `/etc/init.d/cosmos-disk-recovery` + `/usr/sbin/cosmos-disk-recovery` with executable bits and `/etc/default/cosmos-disk-recovery` readable.
7. **Disk-recovery status reports cleanly on empty cache:** `cosmos-disk-recovery status` returns `oc: absent ...` and `stock: absent ...` when `/data/recovery/` is empty; reports `present, valid` after a real SWU is dropped there.
8. **Disk-recovery validate rejects bad inputs:** `cosmos-disk-recovery validate /nonexistent` returns non-zero; `cosmos-disk-recovery validate /tmp/empty.swu` (size 0) returns non-zero; `cosmos-disk-recovery validate /data/recovery/oc-restore.swu` returns 0 once a real ~150 MiB SWU is provisioned there.
9. **Disk-recovery USB scan works:** insert a USB stick with `cosmos-recovery.swu` at the root, then `cosmos-disk-recovery scan-usb` lists the candidate from `/tmp/usb/*` (provided by `usb-automount`).

## Credit

Proudly coded by Pono.

## References

- Issue #184: https://github.com/OpenCentauri/cosmos/issues/184
- Post-mortem committed alongside this change: `docs/post-mortems/2026-05-17-wifi-brick.md`
