### PR TITLE
Bump Fluidd to v1.37.1

### DIFF
--- a/meta-opencentauri/recipes-apps/fluidd/files/opencentauri-fluidd-theme/apply-opencentauri-fluidd-theme.py
+++ b/meta-opencentauri/recipes-apps/fluidd/files/opencentauri-fluidd-theme/apply-opencentauri-fluidd-theme.py
@@ -142,9 +142,26 @@ def patch_main_bundle(webroot):
     # Patch onThemeChange to toggle a data attribute for CSS scoping.
     # We detect OpenCentauri by logo src (not name) because the name field
     # persists across theme switches via Fluidd's object-merge in updateTheme.
-    old_on_theme_change = "async onThemeChange(e,t){let n=Io.framework.theme;n.dark=t.isDark,n.currentTheme.primary=t.color,n.currentTheme[`primary-offset`]=new ft(t.color).desaturate(5).darken(10).toHexString(),n.themes.dark.logo=t.logo.light,n.themes.light.logo=t.logo.dark}"
-    new_on_theme_change = 'async onThemeChange(e,t){let n=Io.framework.theme;n.dark=t.isDark,n.currentTheme.primary=t.color,n.currentTheme[`primary-offset`]=new ft(t.color).desaturate(5).darken(10).toHexString(),n.themes.dark.logo=t.logo.light,n.themes.light.logo=t.logo.dark;document.documentElement.dataset.fluiddTheme=(t.logo?.src===`logo_opencentauri.svg`)?`OpenCentauri`:``}'
-    text = replace_once(text, old_on_theme_change, new_on_theme_change, path)
+    # Use regex so the patch survives minified variable name changes between builds.
+    on_theme_re = re.compile(
+        r'async onThemeChange\(e,t\)\{let n=([a-zA-Z_$][a-zA-Z0-9_$]*)\.framework\.theme;'
+        r'n\.dark=t\.isDark,n\.currentTheme\.primary=t\.color,'
+        r'n\.currentTheme\[`primary-offset`\]=new ([a-zA-Z_$][a-zA-Z0-9_$]*)\(t\.color\)\.desaturate\(5\)\.darken\(10\)\.toHexString\(\),'
+        r'n\.themes\.dark\.logo=t\.logo\.light,n\.themes\.light\.logo=t\.logo\.dark\}'
+    )
+    match = on_theme_re.search(text)
+    if not match:
+        raise RuntimeError(f"{path}: onThemeChange pattern not found")
+    theme_var, color_class = match.groups()
+    old_on_theme_change = match.group(0)
+    new_on_theme_change = (
+        f'async onThemeChange(e,t){{let n={theme_var}.framework.theme;'
+        f'n.dark=t.isDark,n.currentTheme.primary=t.color,'
+        f'n.currentTheme[`primary-offset`]=new {color_class}(t.color).desaturate(5).darken(10).toHexString(),'
+        f'n.themes.dark.logo=t.logo.light,n.themes.light.logo=t.logo.dark;'
+        f'document.documentElement.dataset.fluiddTheme=(t.logo?.src===`logo_opencentauri.svg`)?`OpenCentauri`:``}}'
+    )
+    text = text.replace(old_on_theme_change, new_on_theme_change, 1)
 
     # Override the default favicon globally (all themes show OpenCentauri favicon)
     old_icon = 'get defaultIconDataUrl(){let e=`<svg width=\"56\" height=\"56\" viewBox=\"0 0 56 56\" xmlns=\"http://www.w3.org/2000/svg\"><g><path fill=\"${this.primaryOffsetColor}\" d=\"m14.853 33.757 11.617 9.66q.196.169.419.287l.002.001.044.023.017.009.03.014.027.013.021.01.037.016.01.005c.263.111.54.173.817.185h.01l.044.002h.104l.046-.002h.007a2.3 2.3 0 0 0 .818-.186l.008-.003.041-.018.016-.007.03-.015.032-.015.014-.007.044-.023.004-.002a2.3 2.3 0 0 0 .419-.287l10.86-9.031 5.646 3.727L28 56 9.243 37.398Zm.409-14.452 11.425 7.35c.407.267.86.4 1.313.4s.905-.133 1.312-.4l11.426-7.349 8.737 4.462L28 41.628 6.525 23.767zM28 0l24.42 8.993L28 24.699 3.58 8.99Z\" /><path fill=\"${this.primaryColor}\" d=\"m28 0-.135.05h.15v24.64L52.42 8.991Zm12.738 19.307-11.425 7.347-.06.04a2.4 2.4 0 0 1-1.237.36v14.56l21.459-17.846zm-.347 15.08-10.86 9.031q-.196.167-.418.285l-.006.002-.043.024-.013.007-.033.016-.03.014-.015.007-.041.018-.008.004c-.263.112-.54.173-.819.185h-.007l-.045.002h-.037v12.002l18.021-17.87Z\" /></g></svg>`;return`data:image/svg+xml;base64,${btoa(e)}`}'

--- a/meta-opencentauri/recipes-apps/fluidd/fluidd_1.37.1.bb
+++ b/meta-opencentauri/recipes-apps/fluidd/fluidd_1.37.1.bb
@@ -4,7 +4,7 @@ DESCRIPTION = "Fluidd is a free and open-source Klipper web interface for \
     tablets and mobile with customizable layouts."
 HOMEPAGE = "https://github.com/fluidd-core/fluidd"
 LICENSE = "GPL-3.0-only"
-LIC_FILES_CHKSUM = "file://index.html;md5=e465c9484b3a1201b4cff1978e78b863"
+LIC_FILES_CHKSUM = "file://index.html;md5=3b00ecfc948a3467a588bf3a3eb33a00"
 
 inherit python3native
 
@@ -14,7 +14,7 @@ SRC_URI = "https://github.com/fluidd-core/fluidd/releases/download/v${PV}/fluidd
     file://fluidd.cfg \
     file://opencentauri-fluidd-theme \
 "
-SRC_URI[sha256sum] = "b9f003a82ea9061a77c5b2f47c5cdd15c58c8f5f5532960e811be2b01cf0a00b"
+SRC_URI[sha256sum] = "f08e9d438fdce472553e1ce46a9be62f5ababb4b0f64f65efbd4561d9379653c"
 
 S = "${WORKDIR}/fluidd"
 


### PR DESCRIPTION
Updates the Fluidd web UI package to the latest v1.37.1 release.

## Changes

- **Recipe rename:** `fluidd_1.37.0.bb` → `fluidd_1.37.1.bb`
- **SRC_URI SHA-256:** Updated to `f08e9d438fdce472553e1ce46a9be62f5ababb4b0f64f65efbd4561d9379653c`
- **LIC_FILES_CHKSUM:** Updated to `md5=3b00ecfc948a3467a588bf3a3eb33a00` for the new `index.html`
- **Theme patcher robustness:** Fixed the `onThemeChange` JavaScript patch to use regex instead of hardcoded minified variable names (`Io` → `tJ`, `ft` → `OJ` in v1.37.1). The patcher now dynamically captures the minified variable names so it works across both v1.37.0 and v1.37.1.

## Verification

- [x] Downloaded and verified release zip SHA-256
- [x] Verified `LIC_FILES_CHKSUM` from v1.37.1 `index.html`
- [x] `python3 -m py_compile` passes for `apply-opencentauri-fluidd-theme.py`
- [x] Theme patcher tested against v1.37.1 bundle — applies cleanly
- [x] Theme patcher tested against v1.37.0 bundle — still applies cleanly (backward compatible)
- [x] Verified patched `index.html`, `manifest.webmanifest`, `onThemeChange`, and favicon output in extracted bundles
- [ ] CI build passes

Upstream release notes: https://github.com/fluidd-core/fluidd/releases/tag/v1.37.1
