### PR TITLE
fix: added check on _LOAD_FILAMENT_STEP_DONE for mid-print pauses

### DIFF
--- a/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
+++ b/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
@@ -377,9 +377,15 @@ gcode:
 
 [gcode_macro _LOAD_FILAMENT_STEP_DONE]
 gcode:
-    _CLOSE_PROMPT                    ; Close the loading prompt
-    CLEAN_NOZZLE                            ; Wipe nozzle after loading
-    M104 S0                         ; Turn off nozzle heater
+    {% set global = printer['gcode_macro _global_var'] %}
+    _CLOSE_PROMPT
+    {% if printer.pause_resume.is_paused %}
+        M104 S{global.target_extruder}
+        RESPOND MSG="Filament loaded. Resume when ready."
+    {% else %}
+        CLEAN_NOZZLE
+        M104 S0
+    {% endif %}
    
 [gcode_macro LOAD_FILAMENT]
 gcode:


### PR DESCRIPTION
Previous loading logic would clean and shutdown nozzle temp no matter what once loading is completed. Not good for mid-print pausing and filament changes. Added a check to see if the printer is in a paused state, it keeps target extruder temp and skips cleaning the nozzle (Taken care of by RESUME)