### PR TITLE
fix: crates.io 403 due to missing User-Agent in crate fetcher

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "poky"]
 	path = poky
-	url = https://git.yoctoproject.org/poky
-	branch = scarthgap
+	url = https://github.com/OpenCentauri/cosmos-poky.git
+	branch = scarthgap-crate-ua-fix
 [submodule "meta-sunxi"]
 	path = meta-sunxi
 	url = https://github.com/linux-sunxi/meta-sunxi


### PR DESCRIPTION
## Problem

crates.io began enforcing a descriptive User-Agent policy in ~April 2026. BitBake's `Crate` fetcher inherits a fake Mozilla User-Agent from `Wget`, which crates.io now rejects with 403 Forbidden.

This breaks all Rust crate fetches — including recipes in poky (`librsvg`, `python3-cryptography`, etc.), meta-openembedded, and our own `meta-opencentauri` recipes (`camera-led-bridge`, `atomscreen`, `mcu-flasher`, `serial-multiplexer`).

## Root Cause

Upstream fixed this in master (commit `74c93ec961`, Oct 2024) by changing `wget.py` to use `bitbake/version` everywhere. That commit was never backported to the `scarthgap` LTS branch — it's 1,827 commits ahead and not a clean cherry-pick.

## Fix

- Forked poky → [OpenCentauri/cosmos-poky](https://github.com/OpenCentauri/cosmos-poky)
- Patched `bitbake/lib/bb/fetch2/crate.py` to override `user_agent` with a proper bitbake identifier:
  ```python
  user_agent = "bitbake/2.0 (OpenEmbedded; https://www.openembedded.org/)"
  ```
- Updated `.gitmodules` to point the poky submodule at the fork on branch `scarthgap-crate-ua-fix`

This is a surgical fix: only the `Crate` fetcher is affected. Other HTTP fetches continue using the existing Wget behavior.

## Verification

- [x] Build passes crate fetch stage (`camera-led-bridge` or any Rust recipe)
- [x] No regressions in non-crate HTTP fetches

## References

- Upstream master fix: [poky@74c93ec961](https://git.yoctoproject.org/poky/commit/?id=74c93ec961)
- crates.io User-Agent policy: https://crates.io/policies