### PR TITLE
Add M600 filament-change macro

### DIFF
--- a/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
+++ b/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
@@ -294,6 +294,23 @@ gcode:
 
     M400                            ; Wait for movements to complete
 
+# Filament change. Slicers (and manual colour swaps) emit M600; without this
+# macro Kalico aborts the print with "Unknown command: M600".
+[gcode_macro M600]
+description: Pause the print, unload filament and wait for a reload
+gcode:
+    {% set x = params.X|default(202)|float %}
+    {% set y = params.Y|default(264.5)|float %}
+    {% set z = params.Z|default(10)|float %}
+
+    PAUSE X={x} Y={y} Z_MIN={z}     ; Park and capture print state
+    UNLOAD_FILAMENT                 ; Cut and eject the old filament (keeps current hotend temp)
+
+    RESPOND TYPE=command MSG="action:prompt_begin Filament change"
+    RESPOND TYPE=command MSG="action:prompt_text Filament unloaded. Load new filament with LOAD_FILAMENT, then press RESUME to continue the print."
+    RESPOND TYPE=command MSG="action:prompt_footer_button Ok|_CLOSE_PROMPT"
+    RESPOND TYPE=command MSG="action:prompt_show"
+
 [gcode_macro _HOME_X]
 gcode:
     # Home X


### PR DESCRIPTION
## Summary
Slicers and manual colour swaps emit `M600` to trigger a filament change. No `M600` macro was defined, so Kalico aborted the print with `Unknown command: M600`.

This adds an `M600` macro that:
- pauses the print (parking via the existing `PAUSE` client macro),
- unloads the filament using the existing `UNLOAD_FILAMENT` macro (keeps the current hotend temp so the retract works),
- prompts the operator to load new filament (`LOAD_FILAMENT`) and press `RESUME`.

Fixes #156

## Test plan
- [ ] Start a print, send `M600` mid-print: toolhead parks, filament is cut/ejected, prompt shown.
- [ ] `LOAD_FILAMENT` then `RESUME` continues the print correctly.

Made with [Cursor](https://cursor.com)