### PR TITLE
Guard default bed mesh load on startup

### DIFF
--- a/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
+++ b/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
@@ -326,7 +326,12 @@ gcode:
     RUN_SHELL_COMMAND CMD=CAMERA_LIGHT_ON
   {% endif %}
 
-  BED_MESH_PROFILE LOAD=default
+  # Only load the default mesh if it has actually been created. On a fresh
+  # install the profile does not exist yet and an unconditional load throws
+  # "bed_mesh: Unknown profile [default]" on every boot (issue #110).
+  {% if 'bed_mesh default' in printer.configfile.settings %}
+    BED_MESH_PROFILE LOAD=default
+  {% endif %}
 
 [homing_override]
 axes: yxz


### PR DESCRIPTION
## Summary
The startup `delayed_gcode` unconditionally ran `BED_MESH_PROFILE LOAD=default`. On a fresh install (and any time the `default` profile is absent) this throws `bed_mesh: Unknown profile [default]` on every boot.

Wrap the load in an existence check using the same condition already used by `_CHECK_CALIBRATION_VARS` in `calibration.cfg`.

Fixes #110

## Test plan
- [ ] Boot with no saved bed mesh: no error, no profile loaded.
- [ ] Create a `default` mesh, reboot: profile loads as before.

Made with [Cursor](https://cursor.com)