### PR TITLE
Turn off heaters after a standalone WIPE_NOZZLE

### DIFF
--- a/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
+++ b/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
@@ -84,6 +84,10 @@ gcode:
 [gcode_macro WIPE_NOZZLE]
 gcode:
     {% set bed_temp = params.BED_TEMP|default(60)|float %}
+    # KEEP_HOT=1 leaves the bed/nozzle at calibration temps for a following
+    # BED_MESH_CALIBRATE. KEEP_HOT=0 (default) turns heaters off when the macro
+    # is run on its own, so a standalone wipe does not leave 140/60 on (issue #147).
+    {% set keep_hot = params.KEEP_HOT|default(0)|int %}
 
     G28                             ; Home
     M204 S5000                      ; Set acceleration to 5000 mm/s
@@ -186,10 +190,16 @@ gcode:
     #G90                             ; Absolute positioning
     M400                            ; Wait for completion
 
-    # Heat to calibration temperatures
-    M140 S{bed_temp}                ; Heat bed to target temp
-    M109 S140                       ; Heat nozzle to 140°C and wait
-    M400                            ; Wait for stability
+    {% if keep_hot %}
+        # Heat to calibration temperatures (caller will probe next)
+        M140 S{bed_temp}            ; Heat bed to target temp
+        M109 S140                   ; Heat nozzle to 140°C and wait
+        M400                        ; Wait for stability
+    {% else %}
+        # Standalone wipe: do not leave the machine heated (issue #147)
+        M104 S0                     ; Turn off nozzle heater
+        M140 S0                     ; Turn off bed heater
+    {% endif %}
     M106 S0                         ; Turn off part cooling fan
     SET_FAN_SPEED FAN=model_helper_fan SPEED=0 ; Turn off auxiliary fan
 
@@ -209,7 +219,7 @@ gcode:
     SET_FAN_SPEED FAN=model_helper_fan SPEED=0 ; Turn off auxiliary fan
     SET_FAN_SPEED FAN=box_fan SPEED=0 ; Turn off box fan
 
-    WIPE_NOZZLE BED_TEMP={bed_temp}  ; Clean nozzle before probing
+    WIPE_NOZZLE BED_TEMP={bed_temp} KEEP_HOT=1  ; Clean nozzle before probing, stay at temp
 
     M140 S{bed_temp}                ; Set bed temp
     M104 S140                       ; Set nozzle temp to 140°C


### PR DESCRIPTION
## Summary
`WIPE_NOZZLE` ended by heating the bed to `BED_TEMP` and the nozzle to 140C as preparation for bed meshing. When the macro is run on its own (e.g. a "clean nozzle" action) it left the printer sitting at 140/60 with no print running.

Add a `KEEP_HOT` parameter (default `0`):
- standalone runs now switch the heaters off at the end;
- `BED_MESH_CALIBRATE_WITH_WIPE` passes `KEEP_HOT=1` to preserve the existing calibration behaviour without an extra cool/reheat cycle.

Fixes #147

## Test plan
- [ ] Run `WIPE_NOZZLE` standalone: heaters and fans end at 0.
- [ ] Run `BED_MESH_CALIBRATE_WITH_WIPE`: temps are held through calibration as before.

Made with [Cursor](https://cursor.com)