### PR TITLE
Copy USB gcodes into the gcodes folder so they appear in the print list

### DIFF
--- a/meta-opencentauri/recipes-core/usb-automount/files/usb-mount
+++ b/meta-opencentauri/recipes-core/usb-automount/files/usb-mount
@@ -15,20 +15,24 @@ copy_wpa_config() {
 copy_gcode_files() {
     SRC_DIR="$1"
 
-    mkdir -p /user-resource
+    # Moonraker/virtual_sdcard serve gcodes from /user-resource/gcodes
+    # (/etc/klipper/gcodes is symlinked there). Files copied anywhere else are
+    # not listed in the print interface (issues #158, #80).
+    DEST_DIR="/user-resource/gcodes"
+    mkdir -p "$DEST_DIR"
 
     COPIED=0
-    for file in "$SRC_DIR"/*.gcode; do
+    for file in "$SRC_DIR"/*.gcode "$SRC_DIR"/*.gco "$SRC_DIR"/*.GCODE "$SRC_DIR"/*.GCO; do
         [ -f "$file" ] || continue
         BASENAME=$(basename "$file")
-        [ -f "/user-resource/$BASENAME" ] && continue
+        [ -f "$DEST_DIR/$BASENAME" ] && continue
 
         if [ "$COPIED" -eq 0 ]; then
             uiprompt "Please wait" "Files from the USB are being copied to internal storage, please wait..."
             COPIED=1
         fi
 
-        cp "$file" /user-resource/ || { uiclear; return 1; }
+        cp "$file" "$DEST_DIR/" || { uiclear; return 1; }
     done
 
     [ "$COPIED" -eq 1 ] && uiclear


### PR DESCRIPTION
## Summary
USB gcode files were copied to `/user-resource/` (the root), but Moonraker / `virtual_sdcard` read `/user-resource/gcodes` (`/etc/klipper/gcodes` is symlinked there). As a result files copied from a USB drive never appeared in the print list.

- Copy into `/user-resource/gcodes` instead.
- Also accept `.gco` and uppercase extensions.

Fixes #158
Fixes #80

## Test plan
- [ ] Insert a USB drive with `*.gcode` files: files are copied and listed in Fluidd/Mainsail.

Made with [Cursor](https://cursor.com)