### PR TITLE
Home Y before X in homing_override

### DIFF
--- a/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
+++ b/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
@@ -369,24 +369,26 @@ gcode:
       M400
     {% endif %}
 
-    # First X home. Note this may crash into the back steppers.
+    # Home Y first: homing X first can drive the toolhead into the rear
+    # frame/steppers depending on the starting position (issue #137).
+    {% if home_all or 'Y' in params %}
+      _HOME_Y
+    {% endif %}
+
+    # First X home.
     {% if home_all or 'X' in params %}
       _HOME_X
     {% endif %}
 
-    # First Y Home. 
-    {% if home_all or 'Y' in params %}
-      _HOME_Y
-    {% endif %}
-    
-    # Second X home (if homing both X and Y) to home x at a known good position for sensorless homing
+    # Second Y home (if homing both X and Y) to settle Y at a known good
+    # position for sensorless homing.
     {% if home_all or ('X' in params and 'Y' in params) %}
-      _HOME_X
+      _HOME_Y
     {% endif %}
 
-    # Second Y home just in case the X home caused a jump in Y
+    # Second X home just in case the Y home caused a jump in X.
     {% if home_all or ('X' in params and 'Y' in params) %}
-      _HOME_Y
+      _HOME_X
     {% endif %}
 
     # Restore running current after homing


### PR DESCRIPTION
## Summary
The `homing_override` homed X first, which (per the existing in-code comment) can drive the toolhead into the rear steppers/frame depending on the start position. This reorders the sensorless homing sequence to **Y, X, Y, X**.

Refs #137

> [!WARNING]
> Motion-order change. I do not have hardware to validate this end-to-end — please verify sensorless homing on a real ECC1 before merging.

## Test plan
- [ ] `G28` from several start positions: no collision with rear frame, X/Y home reliably.

Made with [Cursor](https://cursor.com)