### PR TITLE
Explicitly enable force_move

### DIFF
--- a/meta-opencentauri/recipes-apps/klipper/files/machine.cfg
+++ b/meta-opencentauri/recipes-apps/klipper/files/machine.cfg
@@ -20,6 +20,12 @@ restart_method: command
 [danger_options]
 multi_mcu_trsync_timeout: 0.03
 
+# macros.cfg relies on FORCE_MOVE / SET_KINEMATIC_POSITION (homing_override
+# Z clearance, STRAINGAUGE_Z_HOME, UNLOAD_FILAMENT). Enable them explicitly so
+# the homing/unload macros keep working regardless of Kalico defaults.
+[force_move]
+enable_force_move: True
+
 [stepper_x]
 step_pin: PE8
 dir_pin: !PE7


### PR DESCRIPTION
## Summary
`macros.cfg` uses `FORCE_MOVE` / `SET_KINEMATIC_POSITION` (homing_override Z clearance when Z is unhomed, `STRAINGAUGE_Z_HOME`, `UNLOAD_FILAMENT`), but no `[force_move]` section enabled them. In stock Klipper these commands require `enable_force_move: True`. Add it so homing/unload do not depend on Kalico defaults.

> [!NOTE]
> Hardening change. Please confirm on hardware that homing/unload still behave as expected.

## Test plan
- [ ] `G28` with Z unhomed: Z-clearance force move works.
- [ ] `UNLOAD_FILAMENT` / `STRAINGAUGE_Z_HOME` work as before.

Made with [Cursor](https://cursor.com)