### PR TITLE
Remove unused park variables from Klipper macros

### DIFF
--- a/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
+++ b/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
@@ -5,8 +5,7 @@
 
 [gcode_macro _global_var]
 variable_target_extruder: 0
-variable_pause_park:{'x': 240, 'y': 240, 'z': 10, 'e': 2}
-variable_cancel_park:{'x': 240, 'y': 240, 'z': 10, 'e': 5}
+variable_retract_amount: 2
 variable_extruder_temp:{'probing': 140, 'cleaning': 180, 'loading': 230, 'purging': 250}
 variable_fan_state:{'p1': 0.0, 'p2': 0.0, 'p3': 0.0}
 variable_z_maximum_lifting_distance: 256
@@ -158,9 +157,7 @@ rename_existing: PAUSE_BASE
 gcode:
     {% set global = printer['gcode_macro _global_var'] %}
     {% set state = params.STATE|default('normal') %}
-    {% set x_park = global.pause_park.x|float %}
-    {% set y_park = global.pause_park.y|float %}
-    {% set e_retract = global.pause_park.e|float %}
+    {% set retract_amount = global.retract_amount|float %}
     {% set z_lift_max = global.z_maximum_lifting_distance|int %}
     {% set sensor = printer['filament_switch_sensor filament_sensor'] %}
     {% set pos = printer.gcode_move.position %}
@@ -177,7 +174,7 @@ gcode:
 
     {% if ((printer.extruder.temperature + 5) >= printer.extruder.target) and printer.extruder.can_extrude and sensor.enabled and sensor.filament_detected  %}
         M83
-        G1 E-{e_retract} F300
+        G1 E-{retract_amount} F300
     {% endif %}
 
     {% if printer.toolhead.homed_axes|lower == "xyz" %}
@@ -325,7 +322,7 @@ gcode:
 [gcode_macro KICK]
 gcode:
     {% set global = printer['gcode_macro _global_var'] %}
-    {% set e_retract = global.pause_park.e|float %}
+    {% set retract_amount = global.retract_amount|float %}
 
     {% if "xyz" not in printer.toolhead.homed_axes %}
         {action_raise_error("Printer not homed")}
@@ -339,7 +336,7 @@ gcode:
     M83 ; E relative
 
     MOVE_TO_TRAY ; Move to the tray
-    G1 E-{e_retract} F300 ; Retract slightly to reduce pressure during kick
+    G1 E-{retract_amount} F300 ; Retract slightly to reduce pressure during kick
     M106 S255 ; Full blast fan to solidify plastic
     G4 P3000 ; Wait 3 seconds for fan to do its work
     G1 X186 F8000 ; Kick left


### PR DESCRIPTION
## Summary
- Replace the unused pause and cancel park dictionaries with a single retract amount
- Update `PAUSE` and `KICK` to use the shared retract value
- Keep the existing retract behavior while simplifying the macro configuration

## Testing
- Not run (not requested)