### PR TITLE
Restet z offset before calibrating it

### DIFF
--- a/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
+++ b/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
@@ -543,6 +543,7 @@ gcode:
     G0 Z20 F600
     G28 Z ; Home Z with optical
     M400
+    SET_GCODE_OFFSET Z=0 ; imortant to avoid error stacking up on several retries
     BED_MESH_CLEAR
     G90
     G1 X128 Y128 F9000


### PR DESCRIPTION
sets gcode offset to 0 so that if run several times, the previous results gets discarded instead of being added