### PR TITLE
fix: use target headers when building atomscreen

### DIFF
--- a/meta-opencentauri/recipes-apps/atomscreen/atomscreen_0.1.bb
+++ b/meta-opencentauri/recipes-apps/atomscreen/atomscreen_0.1.bb
@@ -12,6 +12,10 @@ S = "${WORKDIR}/git"
 DEPENDS += "fontconfig openssl pkgconfig-native"
 RDEPENDS:${PN} += "fontconfig gui-switcher"
 
+# linuxfb generates framebuffer bindings during compilation. Ensure bindgen
+# uses the target headers instead of headers from the build host.
+export BINDGEN_EXTRA_CLANG_ARGS = "--sysroot=${STAGING_DIR_TARGET}"
+
 INSANE_SKIP:${PN} = "already-stripped"
 
 INITSCRIPT_NAME = "atomscreen"


### PR DESCRIPTION
This PR updates the `atomscreen` recipe to use the target sysroot headers instead of the host ones:
```
| error: failed to run custom build command for `linuxfb v0.3.1`
|   Unable to generate bindings: ClangDiagnostic("/usr/include/linux/types.h:5:10: fatal error: 'asm/types.h' file not found\n")
```