### PR TITLE
Klipper: Read from accelerometer to wake it before shaper calibration

### DIFF
--- a/meta-opencentauri/recipes-apps/klipper/files/calibration.cfg
+++ b/meta-opencentauri/recipes-apps/klipper/files/calibration.cfg
@@ -110,6 +110,9 @@ gcode:
   RUN_SHELL_COMMAND CMD=GUI_STOP
   G28
   M400
+  # Wake the accelerometer up before we try reading data from it
+  ACCELEROMETER_DEBUG_READ CHIP=lis2dw REG=0x0F
+  G4 P500
   SHAPER_CALIBRATE AXIS=X FORCE_SHAPER=mzv
   G4 P1000
   SHAPER_CALIBRATE AXIS=Y FORCE_SHAPER=mzv


### PR DESCRIPTION
I think I was too hasty closing #150 as discord user spaget0119 has also been having this problem
https://discord.com/channels/1367538416539013122/1384643865885151322/1528494762674360320

I don't have the ability to test this right now, but I can't see why it would harm anything, and maybe it would help?