### PR TITLE
python: cut Klipper/Moonraker interpreter memory overhead

### DIFF
--- a/meta-opencentauri/recipes-apps/klipper/files/klipper-init-d
+++ b/meta-opencentauri/recipes-apps/klipper/files/klipper-init-d
@@ -10,7 +10,7 @@
 
 KLIPPY_EXEC="/usr/bin/python3"
 KLIPPER_PRINTER_CONFIG="/etc/klipper/config/printer.cfg"
-KLIPPY_ARGS="-O /usr/share/klipper/klippy/klippy.py $KLIPPER_PRINTER_CONFIG -l /board-resource/klippy.log -a /run/klippy.sock"
+KLIPPY_ARGS="-O -X no_debug_ranges /usr/share/klipper/klippy/klippy.py $KLIPPER_PRINTER_CONFIG -l /board-resource/klippy.log -a /run/klippy.sock"
 PIDFILE="/var/run/klipper.pid"
 KLIPPER_VAR_CONFIG_BUILDER="/usr/bin/build-klipper-var-config"
 KLIPPER_CONFIG_VERSION="0.0.8-2"

--- a/meta-opencentauri/recipes-apps/klipper/files/klipper-init-d
+++ b/meta-opencentauri/recipes-apps/klipper/files/klipper-init-d
@@ -10,7 +10,7 @@
 
 KLIPPY_EXEC="/usr/bin/python3"
 KLIPPER_PRINTER_CONFIG="/etc/klipper/config/printer.cfg"
-KLIPPY_ARGS="-O -X no_debug_ranges /usr/share/klipper/klippy/klippy.py $KLIPPER_PRINTER_CONFIG -l /board-resource/klippy.log -a /run/klippy.sock"
+KLIPPY_ARGS="-X no_debug_ranges /usr/share/klipper/klippy/klippy.py $KLIPPER_PRINTER_CONFIG -l /board-resource/klippy.log -a /run/klippy.sock"
 PIDFILE="/var/run/klipper.pid"
 KLIPPER_VAR_CONFIG_BUILDER="/usr/bin/build-klipper-var-config"
 KLIPPER_CONFIG_VERSION="0.0.8-2"

--- a/meta-opencentauri/recipes-apps/moonraker/files/moonraker-init-d
+++ b/meta-opencentauri/recipes-apps/moonraker/files/moonraker-init-d
@@ -9,7 +9,7 @@
 ### END INIT INFO
 
 MOONRAKER_EXEC="/usr/bin/python3"
-MOONRAKER_ARGS="-m moonraker.moonraker -d /etc/klipper -l /board-resource/moonraker.log -u /run/moonraker.sock"
+MOONRAKER_ARGS="-X no_debug_ranges -m moonraker.moonraker -d /etc/klipper -l /board-resource/moonraker.log -u /run/moonraker.sock"
 PIDFILE="/var/run/moonraker.pid"
 
 export PYTHONPATH="/usr/share/moonraker"


### PR DESCRIPTION
# python: cut interpreter memory overhead on Klipper + Moonraker

## TL;DR for non-specialists

Python (the language Klipper and Moonraker run on) records extra debug
bookkeeping in every running program, and on this board its "optimized"
mode (`-O`) actually uses *more* RAM, not less. This PR turns off the
wasted bookkeeping (`-X no_debug_ranges`) on both services and removes
`-O` from Klipper's startup. Measured on a real printer: **~2.6–3.4 MiB
less RAM used at idle** across the two services versus stock — a big deal
on a 128 MiB board.

## What changed

- `klipper-init-d`: `-O -X no_debug_ranges` → `-X no_debug_ranges`
- `moonraker-init-d`: add `-X no_debug_ranges` (never had `-O`)

Two commits, two lines.

## Benchmarks (carbon2u, CC1, 128 MiB)

Per variant: full image rebuild, md5-verified SWU flash, on-device flag
verification, then **5× (reboot → 120 s settle → capture)**. RSS/PSS from
`/proc/<pid>/smaps_rollup`; Mem/Swap from `free`. No heaters, no motion,
no config changes. Full writeup with all 20 runs:
[PYBENCH.md](https://gist.github.com/pdscomp/a062755da204c914c072de3391ea6c1d).

### `-O` costs memory on both services (like-for-like, no swap pressure)

| Service | without `-O` | with `-O` | Δ RSS | Δ PSS |
|---|---:|---:|---:|---:|
| Moonraker | 31,179 KiB | 32,720 KiB | **+1,541 KiB** | **+2,190 KiB** |
| Klippy | 35,351 KiB | 36,436 KiB | **+1,085 KiB** | **+1,200 KiB** |

Naive 5-run means look closer to a wash because zram swap kicked in more
often under `-O` (3/5 Moonraker runs vs 1/5 baseline) and swapped-out
pages deflate RSS/PSS readings — the table above compares only runs with
no swap activity, which is the honest comparison.

### `no_debug_ranges` (kept from earlier screening)

~1.4 MiB more MemAvailable at idle; restart timing unchanged (Klipper
4–5 s, Moonraker 9–11 s); APIs, camera, GPIO, I²C, PWM, remoteproc all
healthy. Earlier full test log:
[APP.md](https://gist.github.com/pdscomp/a062755da204c914c072de3391ea6c1d)
(same gist).

### Post-flash health (final build)

`/server/info` → `klippy_connected: true`, `klippy_state: ready`.

## Experiments not retained

Tested on earlier screening passes and rejected with data:

- **Moonraker `-O`**: +1.5–2.2 MiB resident (reproduced twice).
- **Matching precompiled `.pyc`**: no steady-state or startup benefit,
  ~856 KiB image cost, complicates read-only-image updates.
- **`MALLOC_ARENA_MAX=2`**: no repeatable settled-idle gain.
- **`python -S`**: ~0.27 MiB, bypasses `.pth` processing — not worth it.
- **Disabling uvloop**: extension isn't active on target; nothing to save.

## Root cause: why `-O` costs RAM here

Follow-up analysis (same-boot A/B, smaps region diffs, gc/tracemalloc
probes, on-device bytecode capture) pinned it down. It's **not** the
bytecode itself — `-O` bytecode is actually 2.2 KiB smaller, docstrings
survive (only `-OO` strips them), and both variants import an identical
module set (452 = 452 for Moonraker).

The Cosmos image ships **2,253 precompiled stdlib `.pyc` files, all at
opt level 0**. Python's cache tag embeds the opt level: plain Python loads
`cpython-312.pyc` (cache hit, fast unmarshal), while `-O` looks for
`cpython-312.opt-1.pyc` — which doesn't exist in the image — and
**recompiles the entire stdlib from source on every service start**. The
rootfs is read-only squashfs, so the new bytecode can't be cached; the
compile-phase allocations permanently inflate the pymalloc arena watermark
by ~1.1–2.2 MiB per service. Startup time series shows exactly this
plateau shape, and `malloc_trim(0)` confirms the delta is retained arena
memory, not live objects (identical gc counts).

Import-trace proof, same boot:

```
plain: # code object from '/usr/lib/python3.12/json/__pycache__/__init__.cpython-312.pyc'
-O:    # code object from /usr/lib/python3.12/json/__init__.py
```

So on this image `-O` is strictly a loss: no assert/docstring benefit
worth having, real RAM and startup-time cost. Full evidence trail in the
[PYBENCH.md gist](https://gist.github.com/pdscomp/a062755da204c914c072de3391ea6c1d)
(root-cause section, plus raw probes and harnesses).

## Scope and rollback

Two-line diff in two init scripts; revert to roll back. NumPy lazy-loading
continues separately in #257.


