### PR TITLE
Klipper: Update hx711s with new architecture

### DIFF
--- a/meta-opencentauri/recipes-apps/klipper/files/machine.cfg
+++ b/meta-opencentauri/recipes-apps/klipper/files/machine.cfg
@@ -228,8 +228,8 @@ horizontal_z_clearance: 0.4
 
 [load_cell_probe]
 sensor_type: hx711s
-sdo_pins: bed:PB14, bed:PC8, bed:PB15, bed:PA8
-sclk_pins: bed:PB13, bed:PC7, bed:PC6, bed:PC9
+dout_pins: bed:PB14, bed:PC8, bed:PB15, bed:PA8
+sclk_pins: bed:PB13, bed:PC7, bed:PC6,  bed:PC9
 sensor_orientation: inverted
 sample_rate: 80
 gain: A-128

--- a/meta-opencentauri/recipes-apps/klipper/files/machine.cfg
+++ b/meta-opencentauri/recipes-apps/klipper/files/machine.cfg
@@ -241,6 +241,8 @@ reference_tare_counts: 71000, 71000, 71000, 71000
 z_offset: 0.0
 pullback_distance: 0.4
 pullback_speed: 1.0
+samples_tolerance: 0.05
+samples_tolerance_retries: 3
 
 [filament_switch_sensor filament_sensor]
 switch_pin: PC0

--- a/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
+++ b/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
@@ -523,6 +523,7 @@ gcode:
     {% for _ in range(2) %}
       G90
       G1 X120 Y-1 F9000
+      G4 P500
       PROBE HOME=Z SAMPLES=3 SAMPLES_TOLERANCE=0.05 BAD_PROBE_RETRIES=3 BAD_PROBE_STRATEGY=RETRY ; Cleaning passes
       G91
       G0 X4 F600
@@ -533,14 +534,15 @@ gcode:
         G4 P300
         G0 Z1 F300
       {% endfor %}
+      G0 Z4 F600
     {% endfor %}
 
     G91
     G0 Z4 F600 ; Move down a Z to get some clearance
     G90
     G1 X128 Y128 F9000
-
-    PROBE HOME=Z SAMPLES=3 SAMPLES_TOLERANCE=0.05 BAD_PROBE_STRATEGY=RETRY ; Pass 3, final pass
+    G4 P500
+    PROBE HOME=Z SAMPLES=3 SAMPLES_TOLERANCE=0.05 BAD_PROBE_RETRIES=3 BAD_PROBE_STRATEGY=RETRY ; Pass 3, final pass
 
     G91 
     G0 Z5 F600                       
@@ -582,7 +584,7 @@ gcode:
     BED_MESH_CLEAR
     G90
     G1 X128 Y128 F9000
-    PROBE HOME=Z SAMPLES=3 SAMPLES_TOLERANCE=0.05 BAD_PROBE_STRATEGY=RETRY ; Pass 3, final pass
+    PROBE HOME=Z SAMPLES=3 SAMPLES_TOLERANCE=0.05 BAD_PROBE_RETRIES=3 BAD_PROBE_STRATEGY=RETRY ; Pass 3, final pass
     M400
     _SAVE_Z_OFFSET
     G91

--- a/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
+++ b/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
@@ -84,7 +84,6 @@ gcode:
         M109 S{global.extruder_temp.probing}
         SET_DISPLAY_TEXT MSG="Creating adaptive bed mesh"
         SET_GCODE_OFFSET Z=0
-        LOAD_CELL_CALIBRATE TARE=TRUE
         BED_MESH_CALIBRATE_BASE ADAPTIVE=1
     {% else %}
         {% if "default" in printer.bed_mesh.profiles %}
@@ -607,18 +606,11 @@ gcode:
 
     M109 S{global.extruder_temp.probing}
     TURN_OFF_FANS
-    LOAD_CELL_CALIBRATE TARE=TRUE
     BED_MESH_CALIBRATE_BASE {rawparams}
 
     {% if not nozzle_z_homing %}
         CALIBRATE_Z_OFFSET
     {% endif %}
-
-[gcode_macro PROBE]
-rename_existing: PROBE_BASE
-gcode:
-    LOAD_CELL_CALIBRATE TARE=TRUE
-    PROBE_BASE {rawparams}
 
 [gcode_macro SCREWS_TILT_CALCULATE]
 rename_existing: SCREWS_TILT_CALCULATE_BASE

--- a/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
+++ b/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
@@ -524,7 +524,7 @@ gcode:
       G90
       G1 X120 Y-1 F9000
       G4 P500
-      PROBE HOME=Z SAMPLES=3 SAMPLES_TOLERANCE=0.05 BAD_PROBE_RETRIES=3 BAD_PROBE_STRATEGY=RETRY ; Cleaning passes
+      PROBE HOME=Z SAMPLES=3 ; Cleaning passes
       G91
       G0 X4 F600
       G0 Z0.8 F300 ; Using pressure of bending the build plate to squish filament
@@ -542,7 +542,7 @@ gcode:
     G90
     G1 X128 Y128 F9000
     G4 P500
-    PROBE HOME=Z SAMPLES=3 SAMPLES_TOLERANCE=0.05 BAD_PROBE_RETRIES=3 BAD_PROBE_STRATEGY=RETRY ; Pass 3, final pass
+    PROBE HOME=Z SAMPLES=3 ; Pass 3, final pass
 
     G91 
     G0 Z5 F600                       
@@ -584,7 +584,7 @@ gcode:
     BED_MESH_CLEAR
     G90
     G1 X128 Y128 F9000
-    PROBE HOME=Z SAMPLES=3 SAMPLES_TOLERANCE=0.05 BAD_PROBE_RETRIES=3 BAD_PROBE_STRATEGY=RETRY ; Pass 3, final pass
+    PROBE HOME=Z SAMPLES=3 ; Pass 3, final pass
     M400
     _SAVE_Z_OFFSET
     G91

--- a/meta-opencentauri/recipes-apps/klipper/kalico_2026.02.00.inc
+++ b/meta-opencentauri/recipes-apps/klipper/kalico_2026.02.00.inc
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=1ebbd3e34237af26da5dc08a4e440464"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
-SRC_URI = "git://github.com/OpenCentauri/kalico.git;protocol=https;branch=hx711s-new \
+SRC_URI = "git://github.com/OpenCentauri/kalico.git;protocol=https;branch=hx711s-new2 \
     file://0001-remove-save-config-subfile-check.patch \
     file://0002-reduce-calibration-difference-tolerance.patch \
     file://0001-Reduce-log-rotate-threshold.patch \
@@ -13,9 +13,9 @@ SRC_URI = "git://github.com/OpenCentauri/kalico.git;protocol=https;branch=hx711s
     file://0001-probe-home-z-includes-z-offset.patch \
     file://0001-force-specific-input-shaper.patch \
 "
-SRCREV = "413e9e3886463d42b5c3fad678969962dac1ab0f"
+SRCREV = "3f166182f82f95584112571b4f7b2258922be60d"
 
-PR = "r8"
+PR = "r9"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Hopefully this fixes the `-1` readigs we were seeing in the previous driver now that we are reading the chips independently. This fix allows us to remove the `LOAD_CELL_CALIBRATE TARE=TRUE` hacks I added to `macros.cfg` as all probing moves call
`LoadCellPrimitives.tare()` unconditionally.
Also updating `sdo_pins` to `dout_pins` to be consistent with the datasheet and the hx71x driver.

Link to kalico branch: https://github.com/OpenCentauri/kalico/commits/rpmsg-with-new-hx71x/