### PR TITLE
Update Fluidd to v1.37.3 and Mainsail to v2.18.2

### DIFF
--- a/meta-opencentauri/recipes-apps/fluidd/fluidd_1.37.3.bb
+++ b/meta-opencentauri/recipes-apps/fluidd/fluidd_1.37.3.bb
@@ -4,7 +4,7 @@ DESCRIPTION = "Fluidd is a free and open-source Klipper web interface for \
     tablets and mobile with customizable layouts."
 HOMEPAGE = "https://github.com/fluidd-core/fluidd"
 LICENSE = "GPL-3.0-only"
-LIC_FILES_CHKSUM = "file://index.html;md5=02c023fdf3a0f62d1a070d1163c7f4c5"
+LIC_FILES_CHKSUM = "file://index.html;md5=4b86906913a0847d07c33e3a67f2094d"
 
 inherit python3native
 
@@ -13,7 +13,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 SRC_URI = "https://github.com/fluidd-core/fluidd/releases/download/v${PV}/fluidd.zip;downloadfilename=fluidd-${PV}.zip;subdir=fluidd \
     file://opencentauri-fluidd-theme \
 "
-SRC_URI[sha256sum] = "e42d4e8b14a3a0b20573485c882cc4dcfac33d9fbd946c8803a942be282e2b6e"
+SRC_URI[sha256sum] = "48e712e5f2cc59f7cfebd458174ddedff60e532ebcba3f9b844167fa27a22571"
 
 S = "${WORKDIR}/fluidd"
 


### PR DESCRIPTION
Update the Fluidd recipe to v1.37.3 and the Mainsail recipe to v2.18.2.\n\nThis refreshes the upstream release checksums for both recipes to match the latest release artifacts.