### PR TITLE
Update Fluidd to v1.37.3 and Mainsail to v2.18.2

### DIFF
--- a/meta-opencentauri/recipes-apps/fluidd/fluidd_1.37.3.bb
+++ b/meta-opencentauri/recipes-apps/fluidd/fluidd_1.37.3.bb
@@ -4,7 +4,7 @@ DESCRIPTION = "Fluidd is a free and open-source Klipper web interface for \
     tablets and mobile with customizable layouts."
 HOMEPAGE = "https://github.com/fluidd-core/fluidd"
 LICENSE = "GPL-3.0-only"
-LIC_FILES_CHKSUM = "file://index.html;md5=02c023fdf3a0f62d1a070d1163c7f4c5"
+LIC_FILES_CHKSUM = "file://index.html;md5=4b86906913a0847d07c33e3a67f2094d"
 
 inherit python3native
 
@@ -13,7 +13,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 SRC_URI = "https://github.com/fluidd-core/fluidd/releases/download/v${PV}/fluidd.zip;downloadfilename=fluidd-${PV}.zip;subdir=fluidd \
     file://opencentauri-fluidd-theme \
 "
-SRC_URI[sha256sum] = "e42d4e8b14a3a0b20573485c882cc4dcfac33d9fbd946c8803a942be282e2b6e"
+SRC_URI[sha256sum] = "48e712e5f2cc59f7cfebd458174ddedff60e532ebcba3f9b844167fa27a22571"
 
 S = "${WORKDIR}/fluidd"
 

--- a/meta-opencentauri/recipes-apps/mainsail/mainsail_2.18.2.bb
+++ b/meta-opencentauri/recipes-apps/mainsail/mainsail_2.18.2.bb
@@ -3,12 +3,12 @@ DESCRIPTION = "Mainsail is the popular web interface for managing and \
     controlling 3D printers with Klipper."
 HOMEPAGE = "https://github.com/mainsail-crew/mainsail"
 LICENSE = "GPL-3.0-only"
-LIC_FILES_CHKSUM = "file://index.html;md5=cda929aa8b78d319a89b240b5df815f9"
+LIC_FILES_CHKSUM = "file://index.html;md5=e041ea1952fb60d9e673d6c3f4d16802"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 SRC_URI = "https://github.com/mainsail-crew/mainsail/releases/download/v${PV}/mainsail.zip;subdir=mainsail"
-SRC_URI[sha256sum] = "d010f4df25557d520ccdbb8e42fc381df2288e6a5c72d3838a5a2433c7a31d4e"
+SRC_URI[sha256sum] = "df2ba7c301f7bfc8ac9f122741a6ba08356d679ecfa1f62f898d0337802d5de5"
 
 S = "${WORKDIR}/mainsail"
 


### PR DESCRIPTION
Update the Fluidd recipe to v1.37.3 and the Mainsail recipe to v2.18.2.

This refreshes the upstream release checksums for both recipes to match the latest release artifacts.