### PR TITLE
Fix issue #59- bump thermistor smooth time

### DIFF
--- a/meta-opencentauri/recipes-apps/klipper/files/machine.cfg
+++ b/meta-opencentauri/recipes-apps/klipper/files/machine.cfg
@@ -143,6 +143,7 @@ rotation_distance: 28.8 #could be 27.3 needs more testing 28.8 default
 nozzle_diameter: 0.4
 filament_diameter: 1.75
 sensor_type: hotend_thermistor
+smooth_time: 2.0
 min_temp: 0
 max_temp: 335
 min_extrude_temp: 180


### PR DESCRIPTION
Issue 59 (https://github.com/OpenCentauri/cosmos/issues/59) appears to be caused by higher powered/lower thermal mass hotends causing issues with PID tuning with the default smooth time of 1.0 seconds. I tested and found that increasing this value to 2.0 seconds provided accurate results and eliminated noise that caused PID tuning to fail. On my testing tuning failed after 30 cycles with 1.0 seconds and succeded reliably after the expected 6 cycles with 2.0 seconds.