### PR TITLE
DragonBreath chamber heater support

### DIFF
--- a/meta-opencentauri/images/opencentauri-image-base.bb
+++ b/meta-opencentauri/images/opencentauri-image-base.bb
@@ -46,6 +46,7 @@ CORE_IMAGE_EXTRA_INSTALL += "\
     iproute2 \
     chrony \
     afc \
+    dragonbreath \
 "
 
 INITRAMFS_IMAGE = "core-image-tiny-initramfs"

--- a/meta-opencentauri/recipes-data/klipper-dragonbreath-addon/dragonbreath_0.1.bb
+++ b/meta-opencentauri/recipes-data/klipper-dragonbreath-addon/dragonbreath_0.1.bb
@@ -1,0 +1,32 @@
+HOMEPAGE = "https://github.com/plastikman/dragonbreath-klipper"
+LICENSE = "GPL-3.0-only"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=ff1231f0087400bc406945200e2f0ef0"
+SUMMARY = "dragonbreath-klipper"
+DESCRIPTION = "Klipper module for the DragonBreath-firmware Panda Breath chamber heater."
+
+SRC_URI = "git://github.com/plastikman/dragonbreath-klipper.git;protocol=https;branch=main"
+
+# Pinned deliberately. The device firmware owns all heater policy, so bump this
+# only after testing the module against a current DragonBreath release.
+# Requires API v2: device firmware 1.0.0 or newer, unchanged through v1.1.10.
+SRCREV = "c5f531b656599e3574571e534c83ec39a78de0b5"
+
+S = "${WORKDIR}/git"
+
+RDEPENDS:${PN} = " \
+    klipper \
+"
+
+do_configure[noexec] = "1"
+do_compile[noexec] = "1"
+
+do_install() {
+    # Module only. The config the user adds to printer.cfg to enable it is
+    # documented rather than shipped, so nothing here can activate itself.
+    install -d ${D}${datadir}/klipper/klippy/extras
+    install -m 0644 ${S}/dragonbreath.py ${D}${datadir}/klipper/klippy/extras/dragonbreath.py
+}
+
+FILES:${PN} = " \
+    ${datadir}/klipper/klippy/extras/dragonbreath.py \
+"


### PR DESCRIPTION
Adds optional support for a Panda Breath running DragonBreath firmware as a chamber heater.

The device remains the heater controller. It enforces its own target clamp, sensor checks, over-temperature faults, cooldown airflow and communications-loss watchdog. Klipper only supplies intent, through the pinned dragonbreath-klipper module.

Packaging only. Installs the module into klippy/extras and nothing else: no config shipped, no cosmos.conf setting, no generated config, no device discovery, and no changes to any existing file except adding the package to the image. It does nothing until the user adds a [dragonbreath] section to printer.cfg.

Setup, for the docs: flash and provision the device, select Klipper/Moonraker as its control source and point it at this printer's Moonraker, give it a static lease or resolvable hostname, then paste the following into printer.cfg, set host, and Save & Restart.

```ini
[dragonbreath]
host: 192.168.1.100    # the device's IP address or hostname
#port: 80
#token: web            # match the control token set on the device, if any
#poll_interval: 2.0    # polling fallback / retry interval, SSE is the normal path
#register_macros: True # registers M141/M191

[heater_generic dragonbreath]
heater_pin: dragonbreath:pwm
sensor_type: dragonbreath
control: watermark
max_delta: 2.0
min_temp: 0
max_temp: 75           # the device hard-caps the requested target at 70c

[verify_heater dragonbreath]
max_error: 600
check_gain_time: 360
hysteresis: 5
heating_gain: 1

[output_pin dragonbreath_filter]
pin: dragonbreath:filter
value: 0
shutdown_value: 0
```

That gives a dragonbreath heater in Mainsail/Fluidd, M141/M191 (registered by the module), SET_PIN PIN=dragonbreath_filter for the filtration blower, and DRAGONBREATH_RESET for a latched device fault.

Driving the chamber from PRINT_START is deliberately not in here. An earlier revision of this PR touched macros.cfg, because CHAMBER=x runs the aux fan and waits on the passive chamber thermistor, which will not reach a slicer-requested chamber temperature when nothing is heating the chamber. Extracting CHAMBER_PREHEAT as an override point solves that better and keeps DragonBreath out of the shipped macros, so that commit is dropped in favour of a user override in printer.cfg:

```ini
[gcode_macro CHAMBER_PREHEAT]
gcode:
    {% set target = [params.TARGET|default(0)|int, 70]|min %}
    {% if target > 0 %}
        {% if "xyz" not in printer.toolhead.homed_axes %}
            G28
        {% endif %}
        SET_DISPLAY_TEXT MSG="Chamber: {target}c"
        SET_HEATER_TEMPERATURE HEATER=dragonbreath TARGET={target}
        M106 S255
        G0 X128 Y128 Z10 F9000
        TEMPERATURE_WAIT SENSOR="heater_generic dragonbreath" MINIMUM={target}
        M107
    {% endif %}
```

The clamp matters: the device will not accept a target above 70 C, so waiting on a higher number never completes. Waiting on the heater the device regulates rather than the printer's own thermistor matters for the same reason.

Module pinned at c5f531b. Requires API v2, so device firmware 1.0.0 or newer; the API is unchanged through the current v1.1.10.

The RAM question from review is handled upstream in plastikman/dragonbreath-klipper#6, which this pin includes. Kalico imports every module in klippy/extras at startup whether or not a config section references it, so urllib and uuid are now deferred until a device is actually configured: an unconfigured printer went from ~3.5 MB of interpreter heap and 57 extra modules to ~200 KB and one.

Build side is covered: CI built the image on this branch, and I also built the recipe standalone against the pinned layer revisions on an aarch64 host. The package contains exactly one file, /usr/share/klipper/klippy/extras/dragonbreath.py, with no QA warnings.

Hardware tested. An independent tester built this branch, flashed it, and confirmed the module loads and the dragonbreath heater appears with a live chamber temperature: 50.2 C against the printer's own chamber sensor at 48.7 C on a cooling machine, sitting at target 0 and off, which is the expected state on connect.

Not exercised in that test: heating itself, the M191 wait, lease heartbeat and watchdog latch-off on lost comms, fault recovery, and the filtration output.
