### PR TITLE
Drop smooth time to 1.5 to cover all* hotends

### DIFF
--- a/meta-opencentauri/recipes-apps/klipper/files/machine.cfg
+++ b/meta-opencentauri/recipes-apps/klipper/files/machine.cfg
@@ -196,7 +196,7 @@ rotation_distance: 28.8 #could be 27.3 needs more testing 28.8 default
 nozzle_diameter: 0.4
 filament_diameter: 1.75
 sensor_type: hotend_thermistor
-smooth_time: 2.0
+smooth_time: 1.5
 min_temp: 0
 max_temp: 335
 min_extrude_temp: 180


### PR DESCRIPTION
smooth time 2.0 was reported to cause PID errors for some users despite being tested with the stock hotend- may be hardware variation?

Regardless though 1.5 worked for the effected user and it worked as well as 2.0 with my TZ hotend so it appears to be a good consensus option that will ensure everything calibrates.