### PR TITLE
G28 rework

### DIFF
--- a/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
+++ b/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
@@ -555,25 +555,31 @@ gcode:
 
 [homing_override]
 axes: xyz # This forces the z position to be at 0 when we start homing, so we can move the Z up before homing.
-set_position_z: 0
 gcode:
     BED_MESH_CLEAR
     G90
+    {% if 'z' not in printer.toolhead.homed_axes %}
+        SET_KINEMATIC_POSITION Z=0
+    {% endif %}
     G0 Z5 F1200 ; 5 up zhop
-    {% if not rawparams %}
+    {% if not rawparams or ('X' in rawparams and 'Y' in rawparams and 'Z' in rawparams) %}
         G28 Y
         G28 X
         G28 Y
         G0 X128 Y128 F4800
         G28 Z
     {% else %}
-        {% if 'X' in rawparams %}
-            G28 X
-        {% endif %}
         {% if 'Y' in rawparams %}
             G28 Y
         {% endif %}
+        {% if 'X' in rawparams %}
+            G28 X
+        {% endif %}
+        {% if 'X' in rawparams and 'Y' in rawparams %}
+            G28 Y
+        {% endif %}
         {% if 'Z' in rawparams %}
+            G0 X128 Y128 F4800
             G28 Z
         {% endif %}
     {% endif %}
@@ -581,7 +587,7 @@ gcode:
     {% if "default" in printer.bed_mesh.profiles %}
         BED_MESH_PROFILE LOAD=default
     {% endif %}
-
+    
 [gcode_macro LOADCELL_Z_HOME]
 gcode:
     {% set global = printer['gcode_macro _global_var'] %}

--- a/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
+++ b/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
@@ -556,14 +556,15 @@ gcode:
 [homing_override]
 gcode:
     BED_MESH_CLEAR
-    {% if 'z' not in printer.toolhead.homed_axes %}
-        SET_KINEMATIC_POSITION Z=0
-    {% endif %}
-    G91
-    G0 Z5 F1200 ; 5 up zhop
-    G90
-
     {% set rawparams = rawparams|default('XYZ', true) %}
+    
+    {% if 'z' not in printer.toolhead.homed_axes %}
+        FORCE_MOVE STEPPER=stepper_z DISTANCE=5 VELOCITY=20 ; 5 up zhop
+    {% else %}
+        G91
+        G0 Z5 F1200 ; 5 up zhop
+        G90
+    {% endif %}
 
     {% if 'Y' in rawparams %}
         G28 Y
@@ -575,7 +576,7 @@ gcode:
         G28 Y
     {% endif %}
     {% if 'Z' in rawparams %}
-        G0 X128 Y128 F4800
+        G0 X128 Y128 F6000
         G28 Z
     {% endif %}
 

--- a/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
+++ b/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
@@ -554,34 +554,29 @@ gcode:
     M400
 
 [homing_override]
-axes: xyz # This forces the z position to be at 0 when we start homing, so we can move the Z up before homing.
 gcode:
     BED_MESH_CLEAR
-    G90
     {% if 'z' not in printer.toolhead.homed_axes %}
         SET_KINEMATIC_POSITION Z=0
     {% endif %}
+    G91
     G0 Z5 F1200 ; 5 up zhop
-    {% if not rawparams or ('X' in rawparams and 'Y' in rawparams and 'Z' in rawparams) %}
+    G90
+
+    {% set rawparams = rawparams|default('XYZ', true) %}
+
+    {% if 'Y' in rawparams %}
         G28 Y
+    {% endif %}
+    {% if 'X' in rawparams %}
         G28 X
+    {% endif %}
+    {% if 'X' in rawparams and 'Y' in rawparams %}
         G28 Y
+    {% endif %}
+    {% if 'Z' in rawparams %}
         G0 X128 Y128 F4800
         G28 Z
-    {% else %}
-        {% if 'Y' in rawparams %}
-            G28 Y
-        {% endif %}
-        {% if 'X' in rawparams %}
-            G28 X
-        {% endif %}
-        {% if 'X' in rawparams and 'Y' in rawparams %}
-            G28 Y
-        {% endif %}
-        {% if 'Z' in rawparams %}
-            G0 X128 Y128 F4800
-            G28 Z
-        {% endif %}
     {% endif %}
 
     {% if "default" in printer.bed_mesh.profiles %}

--- a/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
+++ b/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
@@ -584,7 +584,7 @@ gcode:
         BED_MESH_PROFILE LOAD=default
     {% endif %}
 
-[gcode_macro CG28]
+[gcode_macro _CG28]
 gcode:
     {% set axis = params.AXIS|default('XYZ')|lower %}
     {% if axis not in printer.toolhead.homed_axes %}

--- a/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
+++ b/meta-opencentauri/recipes-apps/klipper/files/macros.cfg
@@ -583,6 +583,13 @@ gcode:
     {% if "default" in printer.bed_mesh.profiles %}
         BED_MESH_PROFILE LOAD=default
     {% endif %}
+
+[gcode_macro CG28]
+gcode:
+    {% set axis = params.AXIS|default('XYZ')|lower %}
+    {% if axis not in printer.toolhead.homed_axes %}
+        G28 {axis|upper}
+    {% endif %}
     
 [gcode_macro LOADCELL_Z_HOME]
 gcode:

--- a/meta-opencentauri/recipes-data/klipper-afc-addon/files/canvas.cfg
+++ b/meta-opencentauri/recipes-data/klipper-afc-addon/files/canvas.cfg
@@ -178,9 +178,7 @@ gcode:
     {% set toolhead_target = printer.extruder.target|int %}
     BED_MESH_CLEAR
     M104 S{global.extruder_temp.cleaning}
-    {% if printer.toolhead.homed_axes != "xyz" %}
-       G28
-    {% endif %}
+    _GC28 AXIS=XY
     G90
     M83
 


### PR DESCRIPTION
allows for independant axes homing, also avoids slamming in max_z if the printer has already homed z