### PR TITLE
Mainsail Panel Extender: custom dashboard panels for addons

### DIFF
--- a/meta-opencentauri/recipes-apps/mainsail-panel-extender/README.md
+++ b/meta-opencentauri/recipes-apps/mainsail-panel-extender/README.md
@@ -1,0 +1,180 @@
+# Mainsail Panel Extender
+
+Framework that lets addon recipes add custom panels to the Mainsail
+dashboard without forking or rebuilding Mainsail. Addon panels are
+first-class citizens: they reuse Mainsail's own Panel component (native
+toolbar with icon + title, collapse button with the native animation,
+theming), render inside the dashboard columns, and appear in
+**Settings > Dashboard** where users can reorder them, move them
+between columns and hide them. Layout and collapse state are stored by
+Mainsail itself in the moonraker database, per viewport, like every
+built-in panel.
+
+## Architecture
+
+Three pieces, no Mainsail fork:
+
+1. **Moonraker** (patch `0002-Serve-web-UI-addon-panels.patch`) serves
+   the addon files. `addons_path` in the `[server]` section enables it
+   and accepts one root per line (the image default is `/var/www/addons`
+   plus `/user-resource/webui-addons`, so runtime-installed addons on
+   writable storage can add panels too — roots are checked per request,
+   no moonraker restart needed):
+   - `/addons/*` — static files from that directory
+   - `/addons/manifest.json` — generated per request: every directory
+     under `<addons_path>/panels/` containing a `panel.js` is listed.
+     Installing a file is all it takes to register an addon.
+2. **Mainsail** (recipe `mainsail_*.bb`) gets one line injected into
+   `index.html` at build time: `<script src="/addons/loader.js">`. The
+   service worker precache revision in `sw.js` is bumped so browsers
+   with a cached page pick up the change.
+3. **`loader.js`** (this recipe) fetches the manifest, loads each
+   `panel.js`, and hooks the running Mainsail app:
+   - extends the `gui/getAllPossiblePanels` Vuex getter with the addon
+     panel names, so Mainsail's own layout machinery (dashboard
+     columns, settings lists, saved layouts) treats them as built-ins;
+   - registers a Vue component `<id>-panel` per addon that renders
+     Mainsail's Panel component with the addon body in its slot;
+   - toolbar buttons and popout menus reuse Vuetify's `v-btn`/`v-menu`.
+
+   If Mainsail internals change in a future version and the hooks fail,
+   the loader logs to the console and falls back to plain cards below
+   the dashboard, so addons stay usable.
+
+## Adding a panel — quick start
+
+A panel is one JavaScript file. Minimal example:
+
+```js
+// panel.js
+window.CosmosPanels.register({
+    id: 'hello',
+    title: 'Hello',
+    mount(el, ctx) {
+        el.textContent = 'Hello from an addon panel'
+    },
+})
+```
+
+Install it to `/var/www/addons/panels/<name>/panel.js` from a recipe:
+
+```bitbake
+SUMMARY = "Hello dashboard panel"
+LICENSE = "GPL-3.0-only"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-3.0-only;md5=c79ff39f19dfec6d293b95dea7b07891"
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+SRC_URI = "file://panel.js"
+RDEPENDS:${PN} = "mainsail-panel-extender"
+
+do_configure[noexec] = "1"
+do_compile[noexec] = "1"
+
+do_install() {
+    install -d ${D}/var/www/addons/panels/hello
+    install -m 0644 ${WORKDIR}/panel.js ${D}/var/www/addons/panels/hello/panel.js
+}
+
+FILES:${PN} = "/var/www/addons/panels/hello"
+```
+
+Add the recipe to the image and rebuild. No manifest to edit, no other
+registration step.
+
+A complete working example ships with the framework: the **Sticky Note**
+panel (`files/stickynote-panel-example/panel.js`, installed to
+`/var/www/addons/panels/stickynote/`). It exercises the whole API —
+inline SVG icon, popout menu with a "Clear note" action, square layout,
+and persistent state in the moonraker database. It is hidden by default
+(`defaultVisible: false`) — enable it in Settings > Dashboard.
+
+## Registration API
+
+```js
+window.CosmosPanels.register({
+    id: 'my-panel',          // REQUIRED. Unique, [a-z0-9-] only, no '_'
+                             // (underscore is reserved by mainsail).
+    title: 'My Panel',       // Toolbar title + name in Settings > Dashboard.
+    icon: 'M12,2L2,7...',    // Optional. Either an MDI SVG path string
+                             // (24x24 viewBox, mainsail convention — copy
+                             // from @mdi/js) or a complete inline
+                             // '<svg>...</svg>' string with any viewBox;
+                             // its fill is recolored to follow the theme.
+                             // Default: a puzzle icon.
+    defaultVisible: false,   // Optional (default true). false = panel
+                             // starts hidden; users enable it in
+                             // Settings > Dashboard. Once they touch it
+                             // there, their choice is saved and wins.
+    mount(el, ctx) {},       // REQUIRED. Build your UI inside el (the
+                             // card body, a v-card__text div).
+    unmount(el) {},          // Optional cleanup (timers, sockets).
+    buttons: [               // Optional toolbar buttons, rendered left of
+                             // the collapse button like native panels.
+        { icon: 'M...', onClick(ctx) {} },   // plain action button
+        { icon: 'M...', menu(el, ctx) {},    // popout menu (native
+          closeOnContentClick: true },       // v-menu). Build content in
+                             // el — fresh on every open. Set
+                             // closeOnContentClick: false for menus with
+                             // controls that should stay open.
+    ],
+})
+```
+
+### Panel lifecycle — what your code must handle
+
+- **`mount` runs every time the panel enters the DOM** — first load and
+  every navigation back to the dashboard — always with a fresh, empty
+  `el`. Rebuild your DOM and reload state in `mount`; don't cache
+  elements across mounts.
+- **Collapse is free.** The minimize button, animation and persistence
+  are Mainsail's. The panel DOM stays alive while collapsed (state such
+  as a half-typed input survives).
+- **Users control placement.** Your panel starts at the bottom of
+  dashboard column 1; users move/hide it in Settings > Dashboard.
+  Don't assume a position or that the panel is visible.
+- **Persistent state goes in the moonraker database**, not
+  localStorage, so it survives reboots and is shared across browsers:
+  `GET/POST /server/database/item` with your own namespace (see the
+  sticky-note example pattern: debounced saves on input).
+- **Styling:** reuse Mainsail's look by using Vuetify utility classes
+  (`v-btn`, `pa-2`, `d-flex`, ...) and theme variables
+  (`var(--v-primary-base)`); colors inherit from the card. Don't set
+  `display` on `el` itself — use an inner wrapper for flex/grid.
+
+### ctx — Moonraker helpers
+
+Same-origin, no auth needed on the device:
+
+- `ctx.apiGet(path)` — GET, resolves to parsed JSON, rejects on non-2xx
+- `ctx.apiPost(path, body?)` — POST with JSON body
+- `ctx.gcode(script)` — run a G-code script
+
+For push updates, open your own WebSocket to `/websocket` (moonraker
+JSON-RPC) or poll.
+
+### Extra assets
+
+Files next to `panel.js` are served under `/addons/panels/<name>/` —
+css, images, extra scripts. Load them from `mount` with relative-to-app
+URLs, e.g. `fetch('/addons/panels/my-panel/data.json')`.
+
+## Runtime-installed and in-development panels
+
+`/user-resource/webui-addons` is writable and scanned per request: drop
+`panels/<name>/panel.js` under it (from an addon installer script, or
+`scp` while developing) and reload the browser — no rebuild, no
+moonraker restart. Addon files are served with `Cache-Control:
+no-cache`. Installing a panel there is safe on images without the
+extender: nothing references the directory.
+
+## Limitations
+
+- Mainsail only. Fluidd has no addon hook (the loader is injected into
+  Mainsail's index.html).
+- In the Settings > Dashboard list, addon panels show Mainsail's
+  generic info icon — the icon mapping there is compiled in. The panel
+  itself shows your icon.
+- The loader touches Mainsail internals (Vuex getter, Panel/VMenu
+  components). A future Mainsail bump may need the loader revisited;
+  until then panels degrade to plain non-collapsible cards and an error
+  is logged to the browser console.

--- a/meta-opencentauri/recipes-apps/mainsail-panel-extender/files/loader.js
+++ b/meta-opencentauri/recipes-apps/mainsail-panel-extender/files/loader.js
@@ -1,0 +1,544 @@
+/*
+ * Mainsail Panel Extender - COSMOS web UI addon panel loader.
+ *
+ * Injected into the Mainsail index.html. Discovers addon panels via
+ * /addons/manifest.json (served by Moonraker, see the addons_path
+ * option), loads each panel script and integrates registered panels
+ * into the Mainsail dashboard as native panels: they reuse Mainsail's
+ * own Panel component (toolbar, collapse button + animation, theming),
+ * render inside the dashboard columns and appear in Settings >
+ * Dashboard where they can be reordered, moved between columns and
+ * hidden. Layout and collapse state are stored by Mainsail itself in
+ * the moonraker database.
+ *
+ * Panel scripts register themselves with:
+ *
+ *   window.CosmosPanels.register({
+ *       id: 'my-panel',            // required, unique, [a-z0-9-] only
+ *       title: 'My Panel',         // toolbar + settings title
+ *       icon: 'M12,2L2,7...',      // optional MDI SVG path (24x24)
+ *       mount(el, ctx) {},         // build your UI in el. Called every
+ *                                  // time the panel (re)enters the DOM
+ *                                  // (route changes), with a fresh el.
+ *       unmount(el) {},            // optional cleanup
+ *       buttons: [                 // optional toolbar buttons
+ *           { icon: 'M...', onClick(ctx) {} },     // plain action
+ *           { icon: 'M...', menu(el, ctx) {} },    // popout menu; build
+ *                                  // its content in el (fresh on every
+ *                                  // open). Pass closeOnContentClick:
+ *                                  // false to keep it open on click.
+ *       ],
+ *   })
+ *
+ * ctx provides Moonraker API helpers:
+ *   ctx.apiGet(path)            -> parsed JSON
+ *   ctx.apiPost(path, body?)    -> parsed JSON
+ *   ctx.gcode(script)           -> run a G-code script
+ *
+ * Integration hooks into Mainsail internals (Vue/Vuex instances and the
+ * Panel/VMenu/VBtn/VIcon components). If those change in a future
+ * Mainsail version, the loader falls back to plain cards.
+ */
+;(function () {
+    'use strict'
+
+    var panels = new Map() // id -> definition
+    var hiddenByDefault = [] // panel names registered with defaultVisible: false
+    var native = null // { Vue, store, i18n } once integrated
+    var failed = false
+
+    var ctx = {
+        apiGet: function (path) {
+            return fetch(path).then(function (r) {
+                if (!r.ok) throw new Error(path + ' -> ' + r.status)
+                return r.json()
+            })
+        },
+        apiPost: function (path, body) {
+            return fetch(path, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: body ? JSON.stringify(body) : undefined,
+            }).then(function (r) {
+                if (!r.ok) throw new Error(path + ' -> ' + r.status)
+                return r.json()
+            })
+        },
+        gcode: function (script) {
+            return ctx.apiPost(
+                '/printer/gcode/script?script=' + encodeURIComponent(script)
+            )
+        },
+    }
+
+    window.CosmosPanels = {
+        register: function (def) {
+            if (
+                !def ||
+                typeof def.mount !== 'function' ||
+                !/^[a-z0-9][a-z0-9-]*$/.test(def.id || '')
+            ) {
+                console.error('[panel-extender] invalid panel registration', def)
+                return
+            }
+            if (panels.has(def.id)) {
+                console.warn('[panel-extender] duplicate panel id ignored:', def.id)
+                return
+            }
+            panels.set(def.id, def)
+            if (def.defaultVisible === false) hiddenByDefault.push(def.id)
+            if (native) installPanel(def)
+            else if (failed) legacySync()
+        },
+        ctx: ctx,
+    }
+
+    // mdi-puzzle, default icon for panels that don't bring one
+    var DEFAULT_ICON =
+        'M20.5,11H19V7C19,5.89 18.1,5 17,5H13V3.5A2.5,2.5 0 0,0 10.5,1A2.5,' +
+        '2.5 0 0,0 8,3.5V5H4A2,2 0 0,0 2,7V10.8H3.5C5,10.8 6.2,12 6.2,13.5C' +
+        '6.2,15 5,16.2 3.5,16.2H2V20A2,2 0 0,0 4,22H7.8V20.5C7.8,19 9,17.8 ' +
+        '10.5,17.8C12,17.8 13.2,19 13.2,20.5V22H17A2,2 0 0,0 19,20V16H20.5A' +
+        '2.5,2.5 0 0,0 23,13.5A2.5,2.5 0 0,0 20.5,11Z'
+
+    /* ------------------------------------------------------------------ */
+    /* Native integration: hook the Vue app and Vuex store                */
+    /* ------------------------------------------------------------------ */
+
+    function capitalizedName(id) {
+        // 'sticky-note' -> 'StickyNote', matching mainsail's getPanelName()
+        return id
+            .split('-')
+            .map(function (s) {
+                return s.charAt(0).toUpperCase() + s.slice(1)
+            })
+            .join('')
+    }
+
+    function integrate(vm) {
+        // vm is the App component instance; the base Vue constructor with
+        // the global component registry lives on the root instance
+        var Vue = vm.$root.constructor
+        var store = vm.$store
+        var i18n = vm.$i18n
+        if (!Vue.component || !store || !i18n) throw new Error('no app hooks')
+
+        // Reactive list of addon panel names. Extending the result of the
+        // gui/getAllPossiblePanels getter makes mainsail's getPanels()
+        // treat addon panels like built-ins: it auto-appends them to the
+        // first dashboard column and the Settings > Dashboard lists, and
+        // accepts them in saved layouts.
+        var names = Vue.observable
+            ? Vue.observable({ list: [] })
+            : new Vue({ data: { list: [] } })
+
+        // panel names in any saved layout of a viewport; a panel absent
+        // here is one mainsail auto-added (default visible:true) — for
+        // defaultVisible:false panels we flip that default until the
+        // user enables them in Settings > Dashboard (which saves them)
+        function savedNames(viewport) {
+            var dash = (store.state.gui || {}).dashboard || {}
+            var out = {}
+            for (var k in dash) {
+                if (k.indexOf(viewport + 'Layout') !== 0) continue
+                ;(dash[k] || []).forEach(function (p) {
+                    if (p && p.name) out[p.name] = true
+                })
+            }
+            return out
+        }
+
+        var getters = store.getters
+        store.getters = new Proxy(getters, {
+            get: function (target, key) {
+                var value = target[key]
+                if (key === 'gui/getAllPossiblePanels')
+                    return value.concat(names.list)
+                if (key === 'gui/getPanels' && hiddenByDefault.length)
+                    return function (viewport, column, onlyVisible) {
+                        var list = value(viewport, column, false)
+                        var saved = savedNames(viewport)
+                        list = list.map(function (p) {
+                            return hiddenByDefault.indexOf(p.name) >= 0 &&
+                                !saved[p.name]
+                                ? Object.assign({}, p, { visible: false })
+                                : p
+                        })
+                        return onlyVisible
+                            ? list.filter(function (p) { return p.visible })
+                            : list
+                    }
+                return value
+            },
+        })
+
+        native = { Vue: Vue, store: store, i18n: i18n, names: names }
+        panels.forEach(installPanel)
+    }
+
+    function installPanel(def) {
+        // Refuse ids that collide with mainsail's own panels — the native
+        // component would win locally while our name pollutes the layouts
+        try {
+            var builtin = native.store.getters['gui/getAllPossiblePanels']
+            if (builtin.indexOf(def.id) >= 0) {
+                console.error(
+                    '[panel-extender] panel id collides with a mainsail ' +
+                        'panel, not installing:', def.id)
+                panels.delete(def.id)
+                return
+            }
+        } catch (e) { /* getter unavailable; proceed */ }
+
+        // Settings > Dashboard shows $t('Panels.<Name>Panel.Headline')
+        var msg = { Panels: {} }
+        msg.Panels[capitalizedName(def.id) + 'Panel'] = {
+            Headline: def.title || def.id,
+        }
+        native.i18n.availableLocales.forEach(function (locale) {
+            native.i18n.mergeLocaleMessage(locale, msg)
+        })
+
+        // The dashboard renders layout entries as <component :is="name + '-panel'">,
+        // resolved through the global registry.
+        native.Vue.component(def.id + '-panel', makeWrapper(def))
+        native.names.list.push(def.id)
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Mainsail component resolution                                      */
+    /* ------------------------------------------------------------------ */
+
+    // Mainsail's Panel component is identified by its unique prop set;
+    // Vuetify components (v-menu, v-btn, v-icon) keep their names in
+    // options.name. All are found in the component registries up the
+    // parent chain (e.g. PageDashboard -> StatusPanel -> Panel).
+    var ctorCache = {}
+
+    function scanComponents(comps, depth, match) {
+        if (!comps) return null
+        var k, c, found
+        for (k in comps) {
+            if (match(comps[k])) return comps[k]
+        }
+        if (depth > 0) {
+            for (k in comps) {
+                c = comps[k]
+                found =
+                    c &&
+                    c.options &&
+                    scanComponents(c.options.components, depth - 1, match)
+                if (found) return found
+            }
+        }
+        return null
+    }
+
+    function findCtor(vm, cacheKey, match) {
+        if (ctorCache[cacheKey]) return ctorCache[cacheKey]
+        for (var p = vm; p; p = p.$parent) {
+            var found = scanComponents(p.$options.components, 1, match)
+            if (found) {
+                ctorCache[cacheKey] = found
+                return found
+            }
+        }
+        return null
+    }
+
+    function byName(name) {
+        return function (c) {
+            return !!(c && c.options && c.options.name === name)
+        }
+    }
+
+    function isPanelCtor(c) {
+        var o = c && c.options
+        return !!(o && o.props && o.props.cardClass && o.props.collapsible)
+    }
+
+    // def.icon may be an MDI path ('M...') or a complete inline '<svg>'
+    // string (e.g. Material Symbols with a non-24x24 viewBox). Inline
+    // SVGs are recolored to follow the theme.
+    function isSvgIcon(icon) {
+        return /^\s*<svg/i.test(icon || '')
+    }
+
+    function themedSvg(icon) {
+        return icon
+            .replace(/fill="[^"]*"/g, 'fill="currentColor"')
+            .replace(/(width|height)="[^"]*"/g, '$1="24"')
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Panel wrapper component                                            */
+    /* ------------------------------------------------------------------ */
+
+    // Renders a toolbar button for a def.buttons entry: a plain action
+    // button, or a native v-menu popout whose content the addon builds.
+    function makeButton(h, vm, b) {
+        var VBtn = findCtor(vm, 'v-btn', byName('v-btn'))
+        var VIcon = findCtor(vm, 'v-icon', byName('v-icon'))
+        var VMenu = b.menu && findCtor(vm, 'v-menu', byName('v-menu'))
+        if (!VBtn || !VIcon) return null
+
+        function btn(data) {
+            // icon + tile matches mainsail's panel toolbar buttons
+            // (square hover, not the round default)
+            data.props = { icon: true, tile: true }
+            return h(VBtn, data, [h(VIcon, [b.icon || DEFAULT_ICON])])
+        }
+
+        if (b.menu && VMenu) {
+            return h(
+                VMenu,
+                {
+                    props: {
+                        offsetY: true,
+                        closeOnContentClick: b.closeOnContentClick !== false,
+                    },
+                    scopedSlots: {
+                        activator: function (sp) {
+                            return btn({ on: sp.on, attrs: sp.attrs })
+                        },
+                    },
+                },
+                [
+                    h({
+                        // fresh content each time the menu opens
+                        render: function (hh) {
+                            return hh('div', {
+                                class:
+                                    'v-card v-sheet v-card__text ' +
+                                    (vm.$vuetify.theme.dark
+                                        ? 'theme--dark'
+                                        : 'theme--light'),
+                            })
+                        },
+                        mounted: function () {
+                            try {
+                                b.menu(this.$el, ctx)
+                            } catch (e) {
+                                console.error('[panel-extender] menu failed', e)
+                            }
+                        },
+                    }),
+                ]
+            )
+        }
+        return btn({
+            on: {
+                click: function () {
+                    if (b.onClick) b.onClick(ctx)
+                },
+            },
+        })
+    }
+
+    // Vue component wrapping the addon body in mainsail's own Panel
+    // component (native toolbar, collapse button + animation, collapse
+    // persistence). Falls back to a plain card if Panel can't be found.
+    function makeWrapper(def) {
+        return {
+            name: def.id + '-panel',
+            props: { panelId: { type: String, default: null } },
+            mounted: function () {
+                try {
+                    def.mount(this.$refs.body, ctx)
+                } catch (e) {
+                    console.error('[panel-extender] mount failed: ' + def.id, e)
+                }
+            },
+            beforeDestroy: function () {
+                if (def.unmount)
+                    try {
+                        def.unmount(this.$refs.body)
+                    } catch (e) {
+                        /* ignore */
+                    }
+            },
+            render: function (h) {
+                var Panel = findCtor(this, 'panel', isPanelCtor)
+                var body = h('div', { class: 'v-card__text', ref: 'body' })
+                if (!Panel) {
+                    // registries may not be reachable yet; retry once the
+                    // tree is attached
+                    var self = this
+                    this.$nextTick(function () {
+                        if (findCtor(self, 'panel', isPanelCtor))
+                            self.$forceUpdate()
+                    })
+                    var t = this.$vuetify.theme.dark
+                        ? 'theme--dark'
+                        : 'theme--light'
+                    return h(
+                        'div',
+                        { class: 'v-card v-sheet panel mb-3 mb-md-6 ' + t },
+                        [
+                            h(
+                                'div',
+                                {
+                                    class: 'v-card__title subheading',
+                                    style: { height: '48px' },
+                                },
+                                def.title || def.id
+                            ),
+                            body,
+                        ]
+                    )
+                }
+                var children = [body]
+                if (def.buttons && def.buttons.length) {
+                    var vm = this
+                    def.buttons.forEach(function (b) {
+                        // straight into Panel's buttons slot — it brings
+                        // its own flex wrapper
+                        var v = makeButton(h, vm, b)
+                        if (v) {
+                            ;(v.data = v.data || {}).slot = 'buttons'
+                            children.push(v)
+                        }
+                    })
+                }
+                var props = {
+                    title: def.title || def.id,
+                    collapsible: true,
+                    cardClass: def.id + '-panel',
+                }
+                if (isSvgIcon(def.icon)) {
+                    // Panel's icon slot allows arbitrary inline SVGs
+                    children.push(
+                        h('span', {
+                            slot: 'icon',
+                            class:
+                                'v-icon notranslate v-icon--left ' +
+                                (this.$vuetify.theme.dark
+                                    ? 'theme--dark'
+                                    : 'theme--light'),
+                            domProps: { innerHTML: themedSvg(def.icon) },
+                        })
+                    )
+                } else {
+                    props.icon = def.icon || DEFAULT_ICON
+                }
+                return h(Panel, { props: props }, children)
+            },
+        }
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Legacy fallback: append plain cards below the dashboard            */
+    /* ------------------------------------------------------------------ */
+
+    var legacyCards = new Map()
+
+    function legacyBuildCard(def) {
+        var t = document.querySelector('.v-application.theme--light')
+            ? 'theme--light'
+            : 'theme--dark'
+        var card = document.createElement('div')
+        card.className = 'v-card v-sheet ' + t + ' panel mb-3'
+        card.dataset.cosmosPanel = def.id
+        var header = document.createElement('header')
+        header.className =
+            'panel-toolbar v-sheet v-toolbar v-toolbar--dense v-toolbar--flat ' + t
+        header.style.height = '48px'
+        header.innerHTML =
+            '<div class="v-toolbar__content" style="height:48px">' +
+            '<div class="v-toolbar__title d-flex align-center">' +
+            '<span class="subheading"></span></div></div>'
+        header.querySelector('.subheading').textContent = def.title || def.id
+        card.appendChild(header)
+        var body = document.createElement('div')
+        body.className = 'v-card__text'
+        card.appendChild(body)
+        return { card: card, body: body, mounted: false }
+    }
+
+    function legacySync() {
+        if (location.pathname !== '/' || panels.size === 0) return
+        var pc = document.getElementById('page-container')
+        if (!pc) return
+        var host = pc.firstElementChild || pc
+        var container = document.getElementById('cosmos-addon-panels')
+        if (!container) {
+            container = document.createElement('div')
+            container.id = 'cosmos-addon-panels'
+            container.className = 'row'
+            container.innerHTML = '<div class="col col-12"></div>'
+        }
+        if (container.parentElement !== host) host.appendChild(container)
+        var column = container.firstElementChild
+        panels.forEach(function (def, id) {
+            var entry = legacyCards.get(id)
+            if (!entry) {
+                entry = legacyBuildCard(def)
+                legacyCards.set(id, entry)
+            }
+            if (entry.card.parentElement !== column) column.appendChild(entry.card)
+            if (!entry.mounted) {
+                entry.mounted = true
+                try {
+                    def.mount(entry.body, ctx)
+                } catch (e) {
+                    console.error('[panel-extender] mount failed: ' + id, e)
+                }
+            }
+        })
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Bootstrap                                                          */
+    /* ------------------------------------------------------------------ */
+
+    function waitForApp() {
+        var app = document.getElementById('app')
+        var vm = app && app.__vue__
+        if (vm && vm.$store && vm.$i18n) {
+            try {
+                integrate(vm)
+            } catch (e) {
+                console.error(
+                    '[panel-extender] native integration failed, ' +
+                        'falling back to plain cards',
+                    e
+                )
+                failed = true
+                new MutationObserver(legacySync).observe(
+                    document.documentElement,
+                    { childList: true, subtree: true }
+                )
+                legacySync()
+            }
+            return
+        }
+        setTimeout(waitForApp, 200)
+    }
+
+    function loadPanels() {
+        fetch('/addons/manifest.json')
+            .then(function (r) {
+                return r.json()
+            })
+            .then(function (manifest) {
+                ;(manifest.panels || []).forEach(function (p) {
+                    var s = document.createElement('script')
+                    s.src = p.script
+                    s.onerror = function () {
+                        console.error('[panel-extender] failed to load', p.script)
+                    }
+                    document.head.appendChild(s)
+                })
+            })
+            .catch(function () {
+                /* no addons available */
+            })
+        waitForApp()
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', loadPanels)
+    } else {
+        loadPanels()
+    }
+})()

--- a/meta-opencentauri/recipes-apps/mainsail-panel-extender/files/stickynote-panel-example/panel.js
+++ b/meta-opencentauri/recipes-apps/mainsail-panel-extender/files/stickynote-panel-example/panel.js
@@ -1,0 +1,79 @@
+/* Sticky Note — example panel for the Mainsail Panel Extender.
+ *
+ * Demonstrates the full panel API:
+ *  - icon: an inline SVG (Material Symbols "note"), recolored to theme
+ *  - mount: rebuilt on every dashboard entry, state reloaded from the
+ *    moonraker database (survives reboots, shared across browsers)
+ *  - buttons: a native popout menu with a "Clear note" action
+ *  - layout: body kept square via aspect-ratio, flex on an inner wrapper
+ */
+var stickynoteClear = null
+
+window.CosmosPanels.register({
+    id: 'stickynote',
+    title: 'Sticky Note',
+    defaultVisible: false, // opt-in: enable it in Settings > Dashboard
+    icon: '<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#e3e3e3"><path d="M200-200h360v-200h200v-360H200v560Zm0 80q-33 0-56.5-23.5T120-200v-560q0-33 23.5-56.5T200-840h560q33 0 56.5 23.5T840-760v400L600-120H200Zm80-280v-80h200v80H280Zm0-160v-80h400v80H280Zm-80 360v-560 560Z"/></svg>',
+    buttons: [
+        {
+            // mdi-dots-vertical
+            icon: 'M12,16A2,2 0 0,1 14,18A2,2 0 0,1 12,20A2,2 0 0,1 10,18A2,2 0 0,1 12,16M12,10A2,2 0 0,1 14,12A2,2 0 0,1 12,14A2,2 0 0,1 10,12A2,2 0 0,1 12,10M12,4A2,2 0 0,1 14,6A2,2 0 0,1 12,8A2,2 0 0,1 10,6A2,2 0 0,1 12,4Z',
+            menu: function (el) {
+                var btn = document.createElement('button')
+                btn.className = 'v-btn v-btn--text v-size--small'
+                btn.textContent = 'Clear note'
+                btn.onclick = function () { stickynoteClear && stickynoteClear() }
+                el.appendChild(btn)
+            },
+        },
+    ],
+    mount: function (el, ctx) {
+        var DB = '/server/database/item'
+        var Q = '?namespace=panel_extender&key=stickynote'
+
+        // keep the note square: body height matches its width. The flex
+        // layout lives on an inner wrapper because the panel toggles the
+        // body's display for collapse.
+        el.style.aspectRatio = '1/1'
+        var wrap = document.createElement('div')
+        wrap.style.cssText = 'display:flex;flex-direction:column;height:100%'
+        el.appendChild(wrap)
+
+        var ta = document.createElement('textarea')
+        ta.placeholder = 'Write a note...'
+        ta.style.cssText =
+            'flex:1 1 auto;min-height:0;width:100%;resize:none;padding:8px;' +
+            'color:inherit;font:inherit;background:rgba(128,128,128,.08);' +
+            'border:1px solid rgba(128,128,128,.35);border-radius:4px;outline:none'
+        var status = document.createElement('div')
+        status.className = 'text-right'
+        status.style.cssText =
+            'font-size:.75rem;opacity:.6;min-height:1.2em;flex:0 0 auto'
+        wrap.appendChild(ta)
+        wrap.appendChild(status)
+
+        ctx.apiGet(DB + Q)
+            .then(function (r) { ta.value = r.result.value || '' })
+            .catch(function () { /* no note yet */ })
+
+        stickynoteClear = function () {
+            ta.value = ''
+            ta.dispatchEvent(new Event('input'))
+        }
+
+        var timer = null
+        ta.addEventListener('input', function () {
+            status.textContent = '...'
+            clearTimeout(timer)
+            timer = setTimeout(function () {
+                ctx.apiPost(DB, {
+                    namespace: 'panel_extender',
+                    key: 'stickynote',
+                    value: ta.value,
+                })
+                    .then(function () { status.textContent = 'saved' })
+                    .catch(function () { status.textContent = 'save failed' })
+            }, 800)
+        })
+    },
+})

--- a/meta-opencentauri/recipes-apps/mainsail-panel-extender/mainsail-panel-extender_0.1.bb
+++ b/meta-opencentauri/recipes-apps/mainsail-panel-extender/mainsail-panel-extender_0.1.bb
@@ -1,0 +1,32 @@
+SUMMARY = "Mainsail Panel Extender"
+DESCRIPTION = "Framework that lets addon packages add custom panels to the \
+    Mainsail dashboard. Installs a loader script served by Moonraker at \
+    /addons/loader.js. Addons install their panels to \
+    /var/www/addons/panels/<name>/panel.js and are discovered at runtime \
+    via /addons/manifest.json."
+LICENSE = "GPL-3.0-only"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-3.0-only;md5=c79ff39f19dfec6d293b95dea7b07891"
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI = " \
+    file://loader.js \
+    file://stickynote-panel-example/panel.js \
+"
+
+do_configure[noexec] = "1"
+do_compile[noexec] = "1"
+
+do_install() {
+    install -d ${D}/var/www/addons/panels
+    install -m 0644 ${WORKDIR}/loader.js ${D}/var/www/addons/loader.js
+
+    # Sticky Note example panel, shipped with the framework
+    install -d ${D}/var/www/addons/panels/stickynote
+    install -m 0644 ${WORKDIR}/stickynote-panel-example/panel.js \
+        ${D}/var/www/addons/panels/stickynote/panel.js
+}
+
+FILES:${PN} = " \
+    /var/www/addons \
+"

--- a/meta-opencentauri/recipes-apps/mainsail/mainsail_2.18.2.bb
+++ b/meta-opencentauri/recipes-apps/mainsail/mainsail_2.18.2.bb
@@ -12,9 +12,12 @@ SRC_URI[sha256sum] = "df2ba7c301f7bfc8ac9f122741a6ba08356d679ecfa1f62f898d033780
 
 S = "${WORKDIR}/mainsail"
 
+PR = "r1"
+
 RDEPENDS:${PN} = " \
     klipper \
     moonraker \
+    mainsail-panel-extender \
 "
 
 do_configure() {
@@ -30,6 +33,15 @@ do_install() {
     install -d ${D}/var/www/mainsail
     cp -r ${S}/* ${D}/var/www/mainsail/
 
+    # Inject the mainsail-panel-extender panel loader (served by moonraker)
+    sed -i 's|</head>|<script src="/addons/loader.js" defer></script></head>|' \
+        ${D}/var/www/mainsail/index.html
+
+    # Bump the service worker precache revision for index.html, otherwise
+    # browsers that cached the unpatched page never fetch the new one
+    NEW_REV=$(md5sum ${D}/var/www/mainsail/index.html | cut -d' ' -f1)
+    sed -i "s|{url:\"index.html\",revision:\"[0-9a-f]*\"}|{url:\"index.html\",revision:\"$NEW_REV\"}|" \
+        ${D}/var/www/mainsail/sw.js
 }
 
 FILES:${PN} = " \

--- a/meta-opencentauri/recipes-apps/moonraker/files/0002-Serve-web-UI-addon-panels.patch
+++ b/meta-opencentauri/recipes-apps/moonraker/files/0002-Serve-web-UI-addon-panels.patch
@@ -1,0 +1,109 @@
+From 09690233af003b2057263ed8b804f7b580f4041d Mon Sep 17 00:00:00 2001
+From: Shawn Rains <shawn.rains@area9.dk>
+Date: Sun, 23 Aug 2026 10:35:59 +0300
+Subject: [PATCH] Serve web UI addon panels
+
+Add addons_path option to [server] to serve web UI addon files from
+a directory (e.g. /var/www/addons) at /addons/. A manifest of
+installed dashboard panels (subdirectories of <addons_path>/panels/
+containing a panel.js) is served at /addons/manifest.json, allowing
+a loader script injected into the web frontend to discover and load
+custom panels contributed by other packages.
+
+Example moonraker.conf:
+
+  [server]
+  addons_path: /var/www/addons
+---
+ moonraker/components/application.py | 71 +++++++++++++++++++++++++++++
+ 1 file changed, 71 insertions(+)
+
+diff --git a/moonraker/components/application.py b/moonraker/components/application.py
+index 22a8ee5..078124d 100644
+--- a/moonraker/components/application.py
++++ b/moonraker/components/application.py
+@@ -300,6 +300,32 @@ class MoonrakerApp:
+                 {"upstream": webcam_uri}
+             )
+ 
++        # Serve web UI addons (e.g. custom dashboard panels). The option
++        # accepts one root per line; later roots let runtime-installed
++        # addons (on writable storage) add panels next to the ones baked
++        # into the image. Roots are checked per request, so a directory
++        # created after startup works without a restart.
++        adp = config.get("addons_path", None)
++        if adp is not None:
++            roots = [
++                os.path.expanduser(line.strip())
++                for line in adp.splitlines() if line.strip()
++            ]
++            if roots:
++                self.mutable_router.add_handler(
++                    "/addons/manifest.json",
++                    AddonManifestHandler,
++                    {"roots": roots}
++                )
++                self.mutable_router.add_handler(
++                    "/addons/(.*)",
++                    AddonFileHandler,
++                    {"roots": roots}
++                )
++                logging.info(
++                    f"Web UI addons enabled, roots: {', '.join(roots)}"
++                )
++
+         # Register handlers
+         logfile = self.server.get_app_args().get('log_file')
+         if logfile:
+@@ -1132,6 +1158,51 @@ class WebClientRootHandler(tornado.web.RequestHandler):
+         with open(index, "rb") as f:
+             self.finish(f.read())
+ 
++# Serves web UI addon files (loader, panel scripts and their assets)
++# from the first configured root containing the requested file
++class AddonFileHandler(tornado.web.RequestHandler):
++    def initialize(self, roots: List[str]) -> None:
++        self.roots = roots
++
++    def get(self, rel_path: str) -> None:
++        rel = os.path.normpath(url_unescape(rel_path, plus=False))
++        if os.path.isabs(rel) or rel.startswith(".."):
++            raise tornado.web.HTTPError(404)
++        for root in self.roots:
++            full = os.path.join(root, rel)
++            if os.path.isfile(full):
++                ctype = mimetypes.guess_type(full)[0] or "application/octet-stream"
++                self.set_header("Content-Type", ctype)
++                # Addon files are small and change on updates, don't cache
++                self.set_header("Cache-Control", "no-cache")
++                with open(full, "rb") as f:
++                    self.finish(f.read())
++                return
++        raise tornado.web.HTTPError(404)
++
++# Lists installed addon panels found under <root>/panels/ of every
++# configured root; the first root wins on duplicate panel names
++class AddonManifestHandler(tornado.web.RequestHandler):
++    def initialize(self, roots: List[str]) -> None:
++        self.roots = roots
++
++    def get(self) -> None:
++        panels: Dict[str, Any] = {}
++        for root in self.roots:
++            pdir = os.path.join(root, "panels")
++            if not os.path.isdir(pdir):
++                continue
++            for name in os.listdir(pdir):
++                if name in panels:
++                    continue
++                if os.path.isfile(os.path.join(pdir, name, "panel.js")):
++                    panels[name] = {
++                        "name": name,
++                        "script": f"/addons/panels/{name}/panel.js"
++                    }
++        self.set_header("Cache-Control", "no-cache")
++        self.finish({"panels": [panels[n] for n in sorted(panels)]})
++
+ class WebcamRedirectHandler(tornado.web.RequestHandler):
+     def initialize(self, upstream: str) -> None:
+         self.upstream = upstream.rstrip("/")

--- a/meta-opencentauri/recipes-apps/moonraker/files/moonraker-readonly.conf
+++ b/meta-opencentauri/recipes-apps/moonraker/files/moonraker-readonly.conf
@@ -10,6 +10,9 @@ max_upload_size: 1024
 klippy_uds_address: /run/klippy.sock
 webcam_redirect: http://127.0.0.1:8080
 web_client: /etc/webui
+addons_path:
+    /var/www/addons
+    /user-resource/webui-addons
 
 [machine]
 provider: none

--- a/meta-opencentauri/recipes-apps/moonraker/moonraker_0.10.0.bb
+++ b/meta-opencentauri/recipes-apps/moonraker/moonraker_0.10.0.bb
@@ -14,6 +14,7 @@ SRC_URI = " \
     file://moonraker.conf \
     file://moonraker-readonly.conf \
     file://0001-Serve-static-files.patch \
+    file://0002-Serve-web-UI-addon-panels.patch \
     file://0001-Reduce-log-rotate-threshold.patch \
 "
 
@@ -21,7 +22,7 @@ SRCREV = "16e530eb663218faa6ccd97ffb0583f1880e2983"
 
 S = "${WORKDIR}/git"
 
-PR = "r1"
+PR = "r2"
 
 inherit python3-dir update-rc.d
 


### PR DESCRIPTION
## What it does

<img width="2193" height="1268" alt="image" src="https://github.com/user-attachments/assets/028bb7fe-0001-4163-8d16-971ac62fa567" />


Adds a small framework that lets addons add custom panels to the Mainsail dashboard without forking or rebuilding Mainsail:

- **moonraker**: new `addons_path` option (patch) serves `/addons/*` and a runtime-generated `/addons/manifest.json` listing installed panels. Accepts multiple roots — one baked into the image (`/var/www/addons`) and one on writable storage (`/user-resource/webui-addons`), so runtime-installed addons can ship panels too. Roots are scanned per request; installing a panel is just dropping a `panels/<name>/panel.js` file.
- **mainsail**: one `<script>` tag injected into `index.html` at build time (with a service-worker precache revision bump so cached browsers pick it up).
- **mainsail-panel-extender**: the loader. Panels register with a small JS API and are integrated natively — they reuse Mainsail's own Panel component (toolbar with icon/title, collapse button + animation, theming), render inside the dashboard columns, support toolbar buttons and v-menu popouts, and appear in **Settings > Dashboard** where users reorder, move and hide them. Layout and collapse state are persisted by Mainsail itself in the moonraker database. If a future Mainsail bump changes internals, the loader falls back to plain cards and logs to the console — the dashboard never breaks.

A developer guide (panel API, lifecycle, examples) is in `recipes-apps/mainsail-panel-extender/README.md`.

## Why it's needed

Addons like ACE/multi-material integrations have printer-side functionality but no place in the web UI — users end up in the console running macros. Mainsail has no plugin system, and maintaining a Mainsail fork per addon isn't sustainable. This gives any addon (image recipes and runtime installers alike) a first-class dashboard panel with zero Mainsail changes beyond one injected script tag.

## Included example

Ships a **Sticky Note** panel (`stickynote-panel-example`) exercising the full API — **disabled by default**; enable it in Settings > Dashboard.

*(Example images to follow.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)